### PR TITLE
Fixup - notify shared calendar subscribers when moving an event

### DIFF
--- a/lib/Publisher/CalDAV/EventRealTimePlugin.php
+++ b/lib/Publisher/CalDAV/EventRealTimePlugin.php
@@ -77,7 +77,12 @@ class EventRealTimePlugin extends \ESN\Publisher\RealTimePlugin {
         list($calendarNodePath, $eventURI) = Utils::splitEventPath($eventPath);
         $calendar = $this->server->tree->getNodeForPath($calendarNodePath);
 
-        list(,, $calendarUid) = explode('/', $calendarNodePath);
+        $parts = explode('/', $calendarNodePath);
+        if (count($parts) < 3) {
+            return true; // Not a calendar
+        }
+
+        list(,, $calendarUid) = $parts;
 
         $options = [
             'action' => 'CREATED',


### PR DESCRIPTION
# Should ignore `moveEvent` when move contact

Related to commit 
- [notify shared calendar subscribers when moving an event](https://github.com/linagora/esn-sabre/commit/20d86fd0b94f126d6f2c4fda1dcfc1ef64cf8379) 

It looks like `moveEvent` for calendar? (The commit messsage, and eventBody is calendar 

When I attempt to MOVE Contact, this logic is still triggered, resulting in an error.

```
[08-Jan-2025 04:02:18] WARNING: [pool www] child 155990 said into stderr: "[2025-01-08 04:02:18] EsnSabre.CRITICAL: Uncaught exception {"exception":"[object] (ErrorException(code: 0): Undefined offset: 2 at /var/www/lib/Publisher/CalDAV/EventRealTimePlugin.php:80)"} []"
```

=> We can ignore it for this case. 

Note that the code below is suggestion by ChatGPT. (I'm not php developer :( ) 