### PR TITLE
Fix endpoint /api/tecknicalToken/introspect

### DIFF
--- a/lib/DAV/Auth/Backend/Esn.php
+++ b/lib/DAV/Auth/Backend/Esn.php
@@ -51,7 +51,7 @@ class Esn extends \Sabre\DAV\Auth\Backend\AbstractBasic {
     }
 
     private function checkAuthByTCalendarToken($token) {
-        $url = $this->apiroot . 'api/tecknicalToken/introspect';
+        $url = $this->apiroot . '/api/tecknicalToken/introspect';
         $headers = ['X-TECHNICAL-TOKEN' => $token];
         $request = new HTTP\Request('GET', $url, $headers);
         return $this->decodeResponse($this->httpClient->send($request));


### PR DESCRIPTION
because missing slash `/` 
-> sabre dav call to : 

`tecknicalToken/introspect` 

![image](https://github.com/user-attachments/assets/f9333646-1acc-4bcd-ac72-81d373959c8e)
