### PR TITLE
feat(log): add optional stack trace logging for exceptions

### DIFF
--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -4,21 +4,18 @@
 services:
   mongodb:
     image: docker.io/library/mongo:3.4.0
-    container_name: mongodb
     hostname: mongodb
     networks:
       - esn-sabre-test-net
 
   ampq_host:
     image: docker.io/library/rabbitmq:3
-    container_name: ampq_host
     hostname: ampq_host
     networks:
       - esn-sabre-test-net
 
   esn_ldap:
     image: esn-sabre-ldap-test
-    container_name: esn_ldap
     hostname: esn_ldap
     environment:
       - LDAP_PORT_NUMBER=389
@@ -31,7 +28,6 @@ services:
 
   esn_test:
     image: esn_sabre_test
-    container_name: esn_sabre_test
     hostname: esn_sabre_test
     environment:
       - LDAP_ADMIN_DN=cn=admin,dc=linagora.com,dc=lng

--- a/lib/Log/ExceptionLoggerPlugin.php
+++ b/lib/Log/ExceptionLoggerPlugin.php
@@ -8,9 +8,15 @@ class ExceptionLoggerPlugin extends DAV\ServerPlugin
 {
     protected $logger;
     protected $server;
+    protected $logTrace = false;
 
     public function __construct($logger) {
         $this->logger = $logger;
+        $env = getenv('LOG_TRACE');
+        if ($env !== false) {
+            $env = strtolower(trim($env));
+            $this->logTrace = in_array($env, ['1','true','yes','on'], true);
+        }
     }
 
     function initialize(DAV\Server $server) {
@@ -47,12 +53,15 @@ class ExceptionLoggerPlugin extends DAV\ServerPlugin
             }
         }
 
+        $context = ['exception' => $e];
+        if ($this->logTrace) {
+            $context['trace'] = $e->getTraceAsString();
+        }
+
         $this->server->getLogger()->log(
             $logLevel,
             'Uncaught exception',
-            [
-                'exception' => $e,
-            ]
+            $context
         );
     }
 

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 
+# Pre Cleanup
+docker compose -f docker-compose.test.yaml down --volumes --remove-orphans || true
+
 docker build -t esn-sabre-ldap-test -f Dockerfile.ldap .
 docker build -t esn_sabre_test .
 
 docker compose -f docker-compose.test.yaml run --rm esn_test
 exit_code=$?
 
-# Always clean
-docker compose -f docker-compose.test.yaml stop
-docker compose -f docker-compose.test.yaml rm --force
+# Post Cleanup
+docker compose -f docker-compose.test.yaml down --volumes --remove-orphans || true
 
 exit $exit_code


### PR DESCRIPTION
resolve https://github.com/linagora/esn-sabre/issues/28
Introduce support for toggling stack trace logging via `LOG_TRACE` env variable. By default, stack traces are not logged. When LOG_TRACE is set to true/1/yes/on, the full exception trace is included in the log context.

Before
<img width="1841" height="82" alt="Screenshot 2025-09-18 at 3 28 44 PM" src="https://github.com/user-attachments/assets/f881215e-bda4-40e4-a45c-4271e07e2e5a" />

After
<img width="1849" height="214" alt="Screenshot 2025-09-18 at 3 29 29 PM" src="https://github.com/user-attachments/assets/4b0a7066-8bec-47f3-908f-b3151cf496e5" />

