### PR TITLE
chore: upgrade php-amqplib from 2.6.x to 3.3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php-amqplib/php-amqplib": "2.6.*",
+        "php-amqplib/php-amqplib": "^3.3",
         "php": ">=7.4",
         "sabre/dav": "4.1.5",
         "sabre/vobject": "dev-waiting-merges-4.2.2 as 4.2.2",


### PR DESCRIPTION
## Summary
- Upgrade php-amqplib dependency from 2.6.* to ^3.3
- No code changes required - API is fully backward compatible
- All 407 tests pass successfully

## Changes
- Updated composer.json to require php-amqplib ^3.3 instead of 2.6.*
- RabbitMQ version in docker-compose.test.yaml (rabbitmq:3) is already compatible

## Test plan
- [x] Run full test suite (407 tests, 898 assertions) - all pass
- [x] Verify AMQP connection and publishing functionality
- [x] Check backward compatibility with existing code

Fixes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)