### PR TITLE
[FIX] Ensure default calendar is always first in getCalendarsForUser

### DIFF
--- a/lib/CalDAV/Backend/Mongo.php
+++ b/lib/CalDAV/Backend/Mongo.php
@@ -157,6 +157,27 @@ class Mongo extends \Sabre\CalDAV\Backend\AbstractBackend implements
             $userCalendars[] = $userCalendar;
         }
 
+        // Extract principalId from principalUri (e.g., "principals/users/123" -> "123")
+        $principalUriParts = explode('/', $principalUri);
+        $principalId = end($principalUriParts);
+
+        // Reorder calendars to put the default calendar (calendarid == principalId) first
+        $defaultCalendar = null;
+        $otherCalendars = [];
+
+        foreach ($userCalendars as $calendar) {
+            if ($calendar['id'][0] === $principalId) {
+                $defaultCalendar = $calendar;
+            } else {
+                $otherCalendars[] = $calendar;
+            }
+        }
+
+        if ($defaultCalendar) {
+            array_unshift($otherCalendars, $defaultCalendar);
+            return $otherCalendars;
+        }
+
         return $userCalendars;
     }
 


### PR DESCRIPTION
## Summary

- Fixes calendar ordering issue after MongoDB restore operations
- Ensures the default calendar (where `calendarid == principalId`) is always returned first by `getCalendarsForUser`
- Prevents ITIP from inserting events into random calendars after data restoration

## Context

When calendars are exported and restored using `mongodump`/`mongorestore`, the original order is not preserved. Since ITIP inserts events into the first calendar returned, this caused events to be inserted into random calendars instead of the default one.

This implementation follows @chibenwa's proposed solution from issue #49.

## Test plan

- [ ] Run existing unit tests to ensure no regression
- [ ] Verify that the default calendar is always returned first
- [ ] Test calendar ordering after MongoDB restore operations
- [ ] Verify ITIP event insertion works correctly

Fixes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)