### PR TITLE
[PERF] Fix slow REPORT requests by avoiding sequential DB reads

### DIFF
--- a/lib/CalDAV/Backend/Mongo.php
+++ b/lib/CalDAV/Backend/Mongo.php
@@ -539,7 +539,13 @@ class Mongo extends \Sabre\CalDAV\Backend\AbstractBackend implements
         $result = [];
         foreach ($collection->find($query, [ 'projection' => $projection ]) as $row) {
             if ($requirePostFilter) {
-                if (!$this->validateFilterForObject((array) $row, $filters)) {
+                // Ensure calendardata is properly passed to avoid sequential DB reads
+                $object = [
+                    'calendarid' => $calendarId,
+                    'uri' => $row['uri'],
+                    'calendardata' => $row['calendardata']
+                ];
+                if (!$this->validateFilterForObject($object, $filters)) {
                     continue;
                 }
             }


### PR DESCRIPTION
## Summary

- Fixes slow REPORT requests (2+ seconds) for calendars with many recurring events
- Eliminates N sequential MongoDB reads during calendar query post-filtering
- Ensures `calendardata` is properly passed to `validateFilterForObject`

## Problem

When `calendarQuery` requires post-filtering (e.g., for time-range filters on recurring events), the current implementation casts `MongoDB\Model\BSONDocument` to an array using `(array) $row`. This cast doesn't preserve keys properly, causing `validateFilterForObject` to not detect the `calendardata` field.

As a result, `validateFilterForObject` calls `getCalendarObject()` for **each event**, making sequential DB reads:
- Calendar with 100 recurring events → 100 additional MongoDB queries
- Total time: 2+ seconds for REPORT requests

## Solution

Explicitly construct a PHP array with the required keys (`calendarid`, `uri`, `calendardata`) before passing to `validateFilterForObject`. Since `calendardata` is already fetched in the initial query projection, this eliminates all sequential database calls.

## Performance Impact

**Before:**
- 1 MongoDB query + N sequential reads (where N = number of events)
- 2+ seconds for power user calendars

**After:**
- 1 MongoDB query only
- Expected massive performance gains

## Test Plan

- [ ] Test REPORT requests on calendars with many recurring events
- [ ] Verify no performance regression on regular calendars
- [ ] Confirm time-range filtering still works correctly

Fixes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)