### PR TITLE
[FIX] Install composer in /usr/local/bin for global PATH access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN pecl install mongodb-1.9.0 \
     && echo "extension=mongodb.so" >> /etc/php/7.0/cli/php.ini
 
 # Set up Sabre DAV
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=bin --filename=composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 # Set up Nginx
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf


### PR DESCRIPTION
## Summary

- Fixes `composer: not found` error during Docker build
- Installs composer in `/usr/local/bin` instead of `bin/` for global PATH access

## Problem

The Dockerfile was installing composer in `bin/composer` (relative path), which is not in the default PATH. This caused the following error during build step 16:

```
/bin/sh: 1: composer: not found
```

## Solution

Changed `--install-dir=bin` to `--install-dir=/usr/local/bin` to install composer globally in a standard location that's in the PATH.

## Test Plan

- [x] Build succeeds with `docker build -t tmp .`
- [x] Composer is accessible globally in the container
- [x] `composer update` runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)