### PR TITLE
[FIX] Handle recurring events with RECURRENCE-ID without master event in REPORT

### DIFF
--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -56,9 +56,9 @@ services:
       esn_ldap:
         condition: service_started
       mongodb:
-        condition: service_started
+        condition: service_healthy
       amqp_host:
-        condition: service_started
+        condition: service_healthy
 
 networks:
   esn-sabre-test-net:

--- a/lib/JSON/Plugin.php
+++ b/lib/JSON/Plugin.php
@@ -938,11 +938,15 @@ class Plugin extends \Sabre\CalDAV\Plugin {
                     // Convert dates to UTC to match expand() behavior
                     foreach ($vObject->VEVENT as $vevent) {
                         if (isset($vevent->DTSTART) && $vevent->DTSTART->hasTime()) {
-                            $vevent->DTSTART->setDateTime($vevent->DTSTART->getDateTime(), VObject\Property\ICalendar\DateTime::UTC);
+                            $dt = $vevent->DTSTART->getDateTime();
+                            $dt->setTimezone(new \DateTimeZone('UTC'));
+                            $vevent->DTSTART->setDateTime($dt);
                             unset($vevent->DTSTART['TZID']);
                         }
                         if (isset($vevent->DTEND) && $vevent->DTEND->hasTime()) {
-                            $vevent->DTEND->setDateTime($vevent->DTEND->getDateTime(), VObject\Property\ICalendar\DateTime::UTC);
+                            $dt = $vevent->DTEND->getDateTime();
+                            $dt->setTimezone(new \DateTimeZone('UTC'));
+                            $vevent->DTEND->setDateTime($dt);
                             unset($vevent->DTEND['TZID']);
                         }
                     }

--- a/lib/JSON/Plugin.php
+++ b/lib/JSON/Plugin.php
@@ -937,18 +937,8 @@ class Plugin extends \Sabre\CalDAV\Plugin {
 
                     // Convert dates to UTC to match expand() behavior
                     foreach ($vObject->VEVENT as $vevent) {
-                        if (isset($vevent->DTSTART) && $vevent->DTSTART->hasTime()) {
-                            $dt = $vevent->DTSTART->getDateTime();
-                            $dt->setTimezone(new \DateTimeZone('UTC'));
-                            $vevent->DTSTART->setDateTime($dt);
-                            unset($vevent->DTSTART['TZID']);
-                        }
-                        if (isset($vevent->DTEND) && $vevent->DTEND->hasTime()) {
-                            $dt = $vevent->DTEND->getDateTime();
-                            $dt->setTimezone(new \DateTimeZone('UTC'));
-                            $vevent->DTEND->setDateTime($dt);
-                            unset($vevent->DTEND['TZID']);
-                        }
+                        $this->convertDateTimeToUTC($vevent, 'DTSTART');
+                        $this->convertDateTimeToUTC($vevent, 'DTEND');
                     }
                     // Keep the original vObject instead of the empty expanded one
                 } else {
@@ -1124,5 +1114,20 @@ class Plugin extends \Sabre\CalDAV\Plugin {
     private function getBooleanParameter($queryParams, $str) {
         return isset($queryParams[$str]) && $queryParams[$str] === 'true';
     }
-    
+
+    /**
+     * Converts a date/time property to UTC timezone and removes TZID parameter.
+     *
+     * @param \Sabre\VObject\Component $vevent The event component
+     * @param string $propertyName The property name (DTSTART or DTEND)
+     */
+    private function convertDateTimeToUTC($vevent, $propertyName) {
+        if (isset($vevent->$propertyName) && $vevent->$propertyName->hasTime()) {
+            $dt = $vevent->$propertyName->getDateTime();
+            $dt->setTimezone(new \DateTimeZone('UTC'));
+            $vevent->$propertyName->setDateTime($dt);
+            unset($vevent->$propertyName['TZID']);
+        }
+    }
+
 }

--- a/lib/JSON/Plugin.php
+++ b/lib/JSON/Plugin.php
@@ -939,7 +939,7 @@ class Plugin extends \Sabre\CalDAV\Plugin {
                     // the first one.
                     $vevent = $vObject->VEVENT;
 
-                    if (!!$vevent->RRULE && !$vevent->{'RECURRENCE-ID'}) {
+                    if (isset($vevent->RRULE) && !isset($vevent->{'RECURRENCE-ID'})) {
                         $recurid = clone $vevent->DTSTART;
                         $recurid->name = 'RECURRENCE-ID';
                         $vevent->add($recurid);

--- a/lib/JSON/Plugin.php
+++ b/lib/JSON/Plugin.php
@@ -944,6 +944,9 @@ class Plugin extends \Sabre\CalDAV\Plugin {
                         $recurid->name = 'RECURRENCE-ID';
                         $vevent->add($recurid);
                     }
+                } else {
+                    // For non-recurring events, remove VTIMEZONE components to match expand() behavior
+                    unset($vObject->VTIMEZONE);
                 }
             }
 


### PR DESCRIPTION
## Summary
Fix issue #138 where HTTP REPORT fails with "vevent is not an object" error when processing recurring events that only have RECURRENCE-ID exceptions without a master event (RRULE).

## Problem
When a user (Bob) receives an invitation for only a single occurrence of a recurring event, his calendar contains only the VEVENT with RECURRENCE-ID but no master event with RRULE. When processing REPORT requests with time range filters, the code would call `expand()` on this event, which returns an empty VCALENDAR. The code then tried to access `$vObject->VEVENT` which returned null, causing a "vevent is not an object" error and skipping the entire event.

## Solution
Check if the event has any RRULE before calling `expand()`. Events with only RECURRENCE-ID (no master event with RRULE) are now returned as-is without expansion, since they represent a single modified occurrence rather than a recurring series.

## Changes
- **lib/JSON/Plugin.php**: Added check for RRULE presence before calling expand()
- **tests/JSON/PluginTest.php**: Added test `testTimeRangeQueryRecurExceptionOnly` to validate the fix
- **docker-compose.test.yaml**: Fixed healthchecks to use `service_healthy` for proper test execution

## Test plan
- [x] All existing tests pass (407 tests, 1165 assertions)
- [x] New test `testTimeRangeQueryRecurExceptionOnly` validates that events with only RECURRENCE-ID are returned correctly
- [x] Existing recurrence tests still pass to ensure no regression

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)