### PR TITLE
[PERF] Skip IMIP processing for partstat-only changes (#128)

### DIFF
--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -56,9 +56,9 @@ services:
       esn_ldap:
         condition: service_started
       mongodb:
-        condition: service_started
+        condition: service_healthy
       amqp_host:
-        condition: service_started
+        condition: service_healthy
 
 networks:
   esn-sabre-test-net:

--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -194,6 +194,7 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
      * 1. If there are no significant changes ($changes is empty) → skip
      * 2. If the recipient is an attendee and the change concerns another attendee's
      *    participation status → skip (only organizer needs this info)
+     * 3. If the recipient is a resource → never skip (resources need all notifications)
      *
      * @param ITip\Message $message The IMIP message to evaluate
      * @param VCalendar|null $oldObject The original calendar object
@@ -214,6 +215,12 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
         // Ensure oldObject has VEVENT
         if (!isset($oldObject->VEVENT) || !isset($newObject->VEVENT)) {
             return false;
+        }
+
+        // Check if recipient is a resource - resources need all notifications
+        $recipientPrincipalUri = \ESN\Utils\Utils::getPrincipalByUri($message->recipient, $this->server);
+        if ($recipientPrincipalUri && \ESN\Utils\Utils::isResourceFromPrincipal($recipientPrincipalUri)) {
+            return false; // Never skip for resources
         }
 
         // Get the organizer email

--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -206,6 +206,16 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
             return false;
         }
 
+        // Parse oldObject if it's a string (raw iCalendar data)
+        if (is_string($oldObject)) {
+            $oldObject = \Sabre\VObject\Reader::read($oldObject);
+        }
+
+        // Ensure oldObject has VEVENT
+        if (!isset($oldObject->VEVENT) || !isset($newObject->VEVENT)) {
+            return false;
+        }
+
         // Get the organizer email
         $organizerEmail = null;
         if (isset($newObject->VEVENT->ORGANIZER)) {
@@ -243,7 +253,7 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
      * @param \Sabre\VObject\Component $newEvent
      * @return bool True if there are significant changes
      */
-    private function hasSignificantPropertyChanges($oldEvent, $newEvent): bool {
+    private function hasSignificantPropertyChanges(\Sabre\VObject\Component $oldEvent, \Sabre\VObject\Component $newEvent): bool {
         $significantProperties = [
             'DTSTART', 'DTEND', 'DURATION', 'SUMMARY', 'DESCRIPTION',
             'LOCATION', 'RRULE', 'EXDATE', 'RDATE', 'SEQUENCE'

--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -73,6 +73,62 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
     }
 
     /**
+     * Override to filter IMIP messages for partstat-only changes.
+     *
+     * Performance optimization for issue #128:
+     * When an attendee changes their PARTSTAT (accepts/declines), SabreDAV generates
+     * IMIP messages to notify all other attendees. However, attendees don't need to
+     * be notified when another attendee's participation status changes - only the
+     * organizer needs this information.
+     *
+     * This override filters out IMIP messages that:
+     * 1. Have no significant changes (empty $changes)
+     * 2. Are sent to attendees about another attendee's participation change
+     *
+     * As suggested by chibenwa in PR #142 review.
+     */
+    protected function processICalendarChange($oldObject = null, VCalendar $newObject, array $addresses, array $ignore = [], &$modified = false) {
+        $broker = new ITip\Broker();
+        $messages = $broker->parseEvent($newObject, $addresses, $oldObject);
+
+        if ($messages) $modified = true;
+
+        foreach ($messages as $message) {
+            if (in_array($message->recipient, $ignore)) {
+                continue;
+            }
+
+            // Skip delivery if there are no significant changes
+            // This happens when only PARTSTAT changes for attendees
+            if ($this->hasNoSignificantChanges($message, $oldObject, $newObject)) {
+                continue;
+            }
+
+            $this->deliver($message);
+
+            // Update schedule status for organizer or attendee
+            if (isset($newObject->VEVENT->ORGANIZER) && ($newObject->VEVENT->ORGANIZER->getNormalizedValue() === $message->recipient)) {
+                if ($message->scheduleStatus) {
+                    $newObject->VEVENT->ORGANIZER['SCHEDULE-STATUS'] = $message->getScheduleStatus();
+                }
+                unset($newObject->VEVENT->ORGANIZER['SCHEDULE-FORCE-SEND']);
+            } else {
+                if (isset($newObject->VEVENT->ATTENDEE)) {
+                    foreach ($newObject->VEVENT->ATTENDEE as $attendee) {
+                        if ($attendee->getNormalizedValue() === $message->recipient) {
+                            if ($message->scheduleStatus) {
+                                $attendee['SCHEDULE-STATUS'] = $message->getScheduleStatus();
+                            }
+                            unset($attendee['SCHEDULE-FORCE-SEND']);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
      *
      * Override default method because:
      *  * user addresses must be the calendar owner ones to handle delegation
@@ -129,5 +185,102 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
         }
 
         return $this->getAddressesForPrincipal($calendarNode->getOwner());
+    }
+
+    /**
+     * Determines if an IMIP message should be skipped due to insignificant changes.
+     *
+     * This implements the filtering logic suggested by chibenwa for issue #128:
+     * 1. If there are no significant changes ($changes is empty) → skip
+     * 2. If the recipient is an attendee and the change concerns another attendee's
+     *    participation status → skip (only organizer needs this info)
+     *
+     * @param ITip\Message $message The IMIP message to evaluate
+     * @param VCalendar|null $oldObject The original calendar object
+     * @param VCalendar $newObject The updated calendar object
+     * @return bool True if message should be skipped, false if it should be delivered
+     */
+    private function hasNoSignificantChanges(ITip\Message $message, $oldObject, VCalendar $newObject): bool {
+        // For new events, always send notifications
+        if ($oldObject === null) {
+            return false;
+        }
+
+        // Get the organizer email
+        $organizerEmail = null;
+        if (isset($newObject->VEVENT->ORGANIZER)) {
+            $organizerEmail = $newObject->VEVENT->ORGANIZER->getNormalizedValue();
+        }
+
+        // Check if recipient is the organizer
+        $isOrganizer = ($organizerEmail === $message->recipient);
+
+        // Get significant property changes between old and new
+        $hasSignificantChanges = $this->hasSignificantPropertyChanges($oldObject->VEVENT, $newObject->VEVENT);
+
+        // Rule 1: If no significant changes, skip for everyone except organizer
+        // (Organizer should still receive PARTSTAT updates from attendees)
+        if (!$hasSignificantChanges && !$isOrganizer) {
+            return true; // Skip: attendee receiving notification about another attendee's PARTSTAT
+        }
+
+        // Rule 2: If there are significant changes, send to everyone
+        if ($hasSignificantChanges) {
+            return false; // Don't skip: significant changes need to be communicated
+        }
+
+        // Organizer receives all changes (including PARTSTAT)
+        return false;
+    }
+
+    /**
+     * Checks if there are significant property changes between old and new event.
+     *
+     * Significant changes are those that affect event details (time, location, etc.),
+     * not just participation status.
+     *
+     * @param \Sabre\VObject\Component $oldEvent
+     * @param \Sabre\VObject\Component $newEvent
+     * @return bool True if there are significant changes
+     */
+    private function hasSignificantPropertyChanges($oldEvent, $newEvent): bool {
+        $significantProperties = [
+            'DTSTART', 'DTEND', 'DURATION', 'SUMMARY', 'DESCRIPTION',
+            'LOCATION', 'RRULE', 'EXDATE', 'RDATE', 'SEQUENCE'
+        ];
+
+        foreach ($significantProperties as $prop) {
+            $oldValue = isset($oldEvent->$prop) ? (string)$oldEvent->$prop : null;
+            $newValue = isset($newEvent->$prop) ? (string)$newEvent->$prop : null;
+
+            if ($oldValue !== $newValue) {
+                return true; // Found a significant change
+            }
+        }
+
+        // Check if attendee list changed (added or removed)
+        $oldAttendees = [];
+        $newAttendees = [];
+
+        if (isset($oldEvent->ATTENDEE)) {
+            foreach ($oldEvent->ATTENDEE as $attendee) {
+                $oldAttendees[] = $attendee->getNormalizedValue();
+            }
+        }
+
+        if (isset($newEvent->ATTENDEE)) {
+            foreach ($newEvent->ATTENDEE as $attendee) {
+                $newAttendees[] = $attendee->getNormalizedValue();
+            }
+        }
+
+        sort($oldAttendees);
+        sort($newAttendees);
+
+        if ($oldAttendees !== $newAttendees) {
+            return true; // Attendee list changed
+        }
+
+        return false; // No significant changes found
     }
 }


### PR DESCRIPTION
## Summary
Implements chibenwa's filtering strategy from PR #142 review to avoid unnecessary IMIP notifications when attendees change their participation status.

## Problem
When attendee A accepts or declines an event with 100+ participants, SabreDAV generates IMIP messages to notify all other attendees B, C, D... However:
- These attendees don't need to know about A's participation change
- Only the organizer needs this information
- This causes cascading notifications leading to server timeouts (504 errors)

## Solution
Filter IMIP messages based on change significance and recipient role:

### Rules
1. **No significant changes + recipient is attendee** → Skip notification
   - When only PARTSTAT changes, attendees don't need to be notified
   - Only organizer receives these updates

2. **Significant changes** → Send to everyone
   - Changes to time, location, summary, description, attendee list, etc.
   - All participants need to know

3. **Organizer** → Always receives all updates
   - Including PARTSTAT changes from attendees

### Significant vs Non-significant Changes
**Significant** (trigger notifications to all):
- DTSTART, DTEND, DURATION (time changes)
- SUMMARY, DESCRIPTION, LOCATION (event details)
- RRULE, EXDATE, RDATE (recurrence rules)
- SEQUENCE (event version)
- Attendee list changes (add/remove)

**Non-significant** (only notify organizer):
- PARTSTAT changes (accept/decline/tentative)

## Implementation
- Override `processICalendarChange()` to filter messages before delivery
- Add `hasNoSignificantChanges()` to determine if message should be skipped
- Add `hasSignificantPropertyChanges()` to detect event property changes
- Fixed `docker-compose.test.yaml` to use `service_healthy` for MongoDB/RabbitMQ

## Test plan
- [ ] Run `./run_test.sh` and verify all tests pass
- [ ] Test scenario 1: Attendee accepts event with 100+ participants
  - Expected: Only organizer receives notification, other attendees don't
- [ ] Test scenario 2: Organizer changes event time
  - Expected: All participants receive notification
- [ ] Test scenario 3: Organizer adds new attendee
  - Expected: All participants receive notification

## Related
- Issue #128 - Original issue about server timeouts
- PR #142 - Original fix attempt (limiting to 20 deliveries)
- @chibenwa's review comment suggesting this approach
- Twake Calendar issue #225 - Related downstream fix
- Issue #147 - Future work: async IMIP processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)