### PR TITLE
[FIX] Send iTIP notifications when inviting attendee to specific occurrence (#154)

### DIFF
--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -218,7 +218,7 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
         }
 
         // Fix for issue #154: For recurring events with occurrence exceptions,
-        // check if the number of occurrences changed (new exception added)
+        // check if the number of occurrences changed (exception added/removed)
         $oldEventCount = count($oldObject->VEVENT);
         $newEventCount = count($newObject->VEVENT);
         if ($oldEventCount !== $newEventCount) {

--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -217,6 +217,14 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
             return false;
         }
 
+        // Fix for issue #154: For recurring events with occurrence exceptions,
+        // check if the number of occurrences changed (new exception added)
+        $oldEventCount = count($oldObject->VEVENT);
+        $newEventCount = count($newObject->VEVENT);
+        if ($oldEventCount !== $newEventCount) {
+            return false; // New occurrence exception added, always send notification
+        }
+
         // Check if recipient is a resource - resources need all notifications
         $recipientPrincipalUri = \ESN\Utils\Utils::getPrincipalByUri($message->recipient, $this->server);
         if ($recipientPrincipalUri && \ESN\Utils\Utils::isResourceFromPrincipal($recipientPrincipalUri)) {


### PR DESCRIPTION
## Summary

Fixes #154 where no iTIP notification was sent when inviting an attendee to a specific occurrence of a recurring event (regression between rc1 and rc5).

## Root Cause

The performance optimization in f1a0056 (issue #128) introduced a `hasNoSignificantChanges()` check that compared only the **master event's** properties when determining if changes were significant.

When adding a new occurrence exception (e.g., inviting Alice to occurrence #2):
- The master event remained unchanged
- The code incorrectly concluded there were no significant changes
- Result: notification was skipped ❌

## Solution

Added a check for the number of VEVENT components:
- If the number changed → new occurrence exception was added/removed → always send notification ✅
- This preserves the PARTSTAT-only optimization while fixing occurrence-specific invitations

## Test Plan

- [ ] Existing tests pass
- [ ] Integration test from https://github.com/linagora/twake-calendar-integration-tests/pull/90 should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)