### PR TITLE
[FEAT] Add --filter and --skip-java options to run_test.sh

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -1,6 +1,33 @@
 #!/bin/bash
 set -euo pipefail
 
+# Usage: ./run_test.sh [--filter=TestClassName] [--skip-java]
+# Examples:
+#   ./run_test.sh --filter=IMipPluginTest
+#   ./run_test.sh --skip-java
+#   ./run_test.sh --filter=IMipPluginTest --skip-java
+
+FILTER=""
+SKIP_JAVA=false
+
+for arg in "$@"; do
+  case $arg in
+    --filter=*)
+      FILTER="${arg#*=}"
+      shift
+      ;;
+    --skip-java)
+      SKIP_JAVA=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $arg"
+      echo "Usage: $0 [--filter=TestClassName] [--skip-java]"
+      exit 1
+      ;;
+  esac
+done
+
 cleanup() {
   echo "Cleaning up..."
   rm -rf it-tests
@@ -14,11 +41,25 @@ docker compose -f docker-compose.test.yaml down --volumes --remove-orphans || tr
 docker build -t esn-sabre-ldap-test -f Dockerfile.ldap .
 docker build -t esn_sabre_test .
 
-docker compose -f docker-compose.test.yaml run --rm esn_test
+# Build PHP test command
+if [ -n "$FILTER" ]; then
+  PHP_CMD="bash -c \"sleep 5 && make lint && vendor/bin/phpunit -c tests/phpunit.xml --filter=$FILTER tests\""
+  echo "Running PHP tests with filter: $FILTER"
+else
+  PHP_CMD="bash -c \"sleep 5 && make lint && make test\""
+  echo "Running all PHP tests"
+fi
+
+docker compose -f docker-compose.test.yaml run --rm esn_test $PHP_CMD
 exit_code_1=$?
 
 if [ $exit_code_1 -ne 0 ]; then
   exit 1
+fi
+
+if [ "$SKIP_JAVA" = true ]; then
+  echo "Skipping Java integration tests"
+  exit 0
 fi
 
 (

--- a/run_test.sh
+++ b/run_test.sh
@@ -43,14 +43,12 @@ docker build -t esn_sabre_test .
 
 # Build PHP test command
 if [ -n "$FILTER" ]; then
-  PHP_CMD="bash -c \"sleep 5 && make lint && vendor/bin/phpunit -c tests/phpunit.xml --filter=$FILTER tests\""
   echo "Running PHP tests with filter: $FILTER"
+  docker compose -f docker-compose.test.yaml run --rm esn_test bash -c "sleep 5 && make lint && vendor/bin/phpunit -c tests/phpunit.xml --filter=$FILTER tests"
 else
-  PHP_CMD="bash -c \"sleep 5 && make lint && make test\""
   echo "Running all PHP tests"
+  docker compose -f docker-compose.test.yaml run --rm esn_test bash -c "sleep 5 && make lint && make test"
 fi
-
-docker compose -f docker-compose.test.yaml run --rm esn_test $PHP_CMD
 exit_code_1=$?
 
 if [ $exit_code_1 -ne 0 ]; then


### PR DESCRIPTION
## Summary

Improves developer experience by allowing selective test execution in `run_test.sh`.

**New options:**
- `--filter=TestClassName`: Run only specific PHP test(s)
- `--skip-java`: Skip Java integration tests entirely

**Benefits:**
- ⚡ Drastically reduces test iteration time during development
- 🎯 Focus on specific tests without running the full suite
- 💰 Saves time when only PHP changes need testing

## Usage Examples

```bash
# Run single PHP test class
./run_test.sh --filter=IMipPluginTest

# Run PHP tests without Java integration tests
./run_test.sh --skip-java

# Combine both options
./run_test.sh --filter=IMipPluginTest --skip-java

# Original behavior (run everything)
./run_test.sh
```

## Test plan
- [x] Script accepts new options correctly
- [x] Backward compatible (no args = original behavior)
- [ ] Verify --filter works with phpunit
- [ ] Verify --skip-java properly skips Java tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)