### PR TITLE
feat: add MAX_RECURRENCES environment variable (#173)

### DIFF
--- a/doc/CONFIGURE.md
+++ b/doc/CONFIGURE.md
@@ -19,7 +19,11 @@ The following ENV variables needs to be set:
  - AMQP_PASSWORD
  - SABRE_ENV
 
- Additionally LDAP setup is done solely by ENV variables:
+ Additionally the following optional ENV variables can be set:
+
+ - MAX_RECURRENCES (optional): Maximum number of recurring event instances to expand (default: 3500, set to -1 to disable limit)
+
+ LDAP setup is done solely by ENV variables:
 
  - LDAP_ADMIN_DN
  - LDAP_ADMIN_PASSWORD

--- a/esn.php
+++ b/esn.php
@@ -20,6 +20,12 @@ define('SABRE_ENV', (!empty($config['environment']) && !empty($config['environme
 // settings
 date_default_timezone_set('UTC');
 
+// Configure max recurrences if specified
+$maxRecurrences = getenv('MAX_RECURRENCES');
+if ($maxRecurrences !== false) {
+    \Sabre\VObject\Settings::$maxRecurrences = (int)$maxRecurrences;
+}
+
 define('PRINCIPALS_COLLECTION', 'principals');
 define('PRINCIPALS_USERS', 'principals/users');
 define('PRINCIPALS_TECHNICAL_USER', 'principals/technicalUser');

--- a/tests/CalDAV/Backend/MongoRecurrenceExpansionTest.php
+++ b/tests/CalDAV/Backend/MongoRecurrenceExpansionTest.php
@@ -35,4 +35,96 @@ class MongoRecurrenceExpansionTest extends RecurrenceExpansionTestBase {
         // Generate MongoDB ObjectIds directly like MongoTest does
         return [(string) new \MongoDB\BSON\ObjectId(), (string) new \MongoDB\BSON\ObjectId()];
     }
+
+    /**
+     * Test that maxRecurrences setting limits the number of expanded instances
+     * This validates the MAX_RECURRENCES environment variable functionality
+     */
+    function testMaxRecurrencesLimit() {
+        $backend = $this->getBackend();
+        $id = $this->generateId();
+
+        // Save original maxRecurrences value
+        $originalMaxRecurrences = \Sabre\VObject\Settings::$maxRecurrences;
+
+        try {
+            // Set a low limit for testing (50 instances)
+            \Sabre\VObject\Settings::$maxRecurrences = 50;
+
+            // Create a daily event with 40 occurrences (within limit)
+            $ical = join("\r\n", [
+                'BEGIN:VCALENDAR',
+                'VERSION:2.0',
+                'PRODID:-//Test//Test//EN',
+                'BEGIN:VEVENT',
+                'UID:within-limit-event',
+                'DTSTART:20250101T100000Z',
+                'DTEND:20250101T110000Z',
+                'RRULE:FREQ=DAILY;COUNT=40',
+                'SUMMARY:Event Within Limit',
+                'END:VEVENT',
+                'END:VCALENDAR',
+                ''
+            ]);
+
+            $backend->createCalendarObject($id, "within-limit.ics", $ical);
+
+            // Query should succeed for events within the limit
+            $filters = [
+                'name' => 'VCALENDAR',
+                'comp-filters' => [
+                    [
+                        'name' => 'VEVENT',
+                        'comp-filters' => [],
+                        'prop-filters' => [],
+                        'is-not-defined' => false,
+                        'time-range' => [
+                            'start' => new \DateTime('2025-01-01T00:00:00Z'),
+                            'end' => new \DateTime('2025-02-28T23:59:59Z'),
+                        ],
+                    ],
+                ],
+                'prop-filters' => [],
+                'is-not-defined' => false,
+                'time-range' => null,
+            ];
+
+            $result = $backend->calendarQuery($id, $filters);
+            $this->assertEquals(['within-limit.ics'], $result, 'Should find event with COUNT=40 when maxRecurrences=50');
+
+            // Now test that exceeding the limit throws an exception
+            $exceptionThrown = false;
+            try {
+                // Create a daily event with 100 occurrences (exceeds limit)
+                $ical2 = join("\r\n", [
+                    'BEGIN:VCALENDAR',
+                    'VERSION:2.0',
+                    'PRODID:-//Test//Test//EN',
+                    'BEGIN:VEVENT',
+                    'UID:exceeds-limit-event',
+                    'DTSTART:20250101T100000Z',
+                    'DTEND:20250101T110000Z',
+                    'RRULE:FREQ=DAILY;COUNT=100',
+                    'SUMMARY:Event Exceeding Limit',
+                    'END:VEVENT',
+                    'END:VCALENDAR',
+                    ''
+                ]);
+
+                $backend->createCalendarObject($id, "exceeds-limit.ics", $ical2);
+
+                // Try to query - should fail during query processing
+                $backend->calendarQuery($id, $filters);
+            } catch (\Sabre\VObject\Recur\MaxInstancesExceededException $e) {
+                $exceptionThrown = true;
+                $this->assertStringContainsString('50', $e->getMessage(), 'Exception should mention the limit of 50');
+            }
+
+            $this->assertTrue($exceptionThrown, 'MaxInstancesExceededException should be thrown when maxRecurrences is exceeded');
+
+        } finally {
+            // Restore original maxRecurrences value
+            \Sabre\VObject\Settings::$maxRecurrences = $originalMaxRecurrences;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Add support for configuring the maximum number of recurring event instances via the `MAX_RECURRENCES` environment variable.

This addresses issue #173 by allowing administrators to:
- Configure `Sabre\VObject\Settings::$maxRecurrences` via environment variable
- Protect against DDOS attacks from excessive recurrence expansion
- Maintain default behavior (3500 instances) when not specified
- Optionally disable the limit by setting to -1

## Changes
- **esn.php**: Read `MAX_RECURRENCES` env var and configure `Sabre\VObject\Settings::$maxRecurrences`
- **doc/CONFIGURE.md**: Document the new optional environment variable
- **tests/CalDAV/Backend/MongoRecurrenceExpansionTest.php**: Add comprehensive test validating the limit enforcement

## Test plan
- [x] Verify PHP syntax is valid
- [x] Run `MongoRecurrenceExpansionTest` test suite (15 tests, 34 assertions) ✅
- [x] Test validates events within limit work correctly
- [x] Test validates exceeding limit throws `MaxInstancesExceededException`
- [x] Test restores original setting after execution

## Implementation details
The implementation follows existing patterns in the codebase:
- Uses `getenv()` to read environment variables (like LDAP settings)
- Only applies configuration if explicitly set (preserves default behavior)
- Test properly saves/restores original value to avoid side effects

Fixes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)