### PR TITLE
fix: publish AMQP messages for external iTip events (#185)

### DIFF
--- a/lib/CalDAV/Backend/Esn.php
+++ b/lib/CalDAV/Backend/Esn.php
@@ -28,6 +28,16 @@ class Esn extends Mongo {
     }
 
     /**
+     * Get the principal backend
+     *
+     * @return BackendInterface
+     */
+    public function getPrincipalBackend()
+    {
+        return $this->principalBackend;
+    }
+
+    /**
      *
      * Get user calendars.
      *

--- a/run_test.sh
+++ b/run_test.sh
@@ -61,7 +61,7 @@ if [ "$SKIP_JAVA" = true ]; then
 fi
 
 (
-  git clone https://github.com/linagora/twake-calendar-integration-tests.git -b sabre-185-for-testing it-tests
+  git clone https://github.com/linagora/twake-calendar-integration-tests.git it-tests
   cd it-tests
   bash pre-build.sh esn_sabre_test
   mvn clean install -Dtest=com.linagora.dav.sabrev4.**

--- a/run_test.sh
+++ b/run_test.sh
@@ -61,7 +61,7 @@ if [ "$SKIP_JAVA" = true ]; then
 fi
 
 (
-  git clone https://github.com/linagora/twake-calendar-integration-tests.git it-tests
+  git clone https://github.com/linagora/twake-calendar-integration-tests.git -b sabre-185-for-testing it-tests
   cd it-tests
   bash pre-build.sh esn_sabre_test
   mvn clean install -Dtest=com.linagora.dav.sabrev4.**


### PR DESCRIPTION
This is a test branch to validate the fix for #185 with integration tests.

## Summary

Fixes #185 by ensuring external iTip events (from non-local organizers) publish AMQP messages for search indexing and alarm management.

## Changes

When an external organizer sends an iTip REQUEST/CANCEL and the event doesn't exist yet in the recipient's calendar:
- Construct the expected event path using schedule-default-calendar-URL
- Use iTipMessage->message as event data
- Publish AMQP messages (EVENT_REQUEST, EVENT_ALARM_REQUEST, etc.)

## Test plan

- [x] All 413 PHP tests pass
- [ ] Java integration tests (https://github.com/linagora/twake-calendar-integration-tests/pull/108)

## Notes

This branch is prefixed with `nomerge-` to indicate it's for testing purposes. If tests pass, we'll create a proper PR from a feature branch.

Related: #184 (different approach for alarm topics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)