### PR TITLE
fix: handle boolean filter values in calendarQuery (issue #188)

### DIFF
--- a/lib/CalDAV/Backend/Mongo.php
+++ b/lib/CalDAV/Backend/Mongo.php
@@ -522,7 +522,7 @@ class Mongo extends \Sabre\CalDAV\Backend\AbstractBackend implements
         }
 
         // Figuring out if there's a component filter
-        if (!empty($filters['comp-filters']) && is_array($filters['comp-filters']) && count($filters['comp-filters']) > 0 && !$filters['comp-filters'][0]['is-not-defined']) {
+        if (!empty($filters['comp-filters']) && is_array($filters['comp-filters']) && !$filters['comp-filters'][0]['is-not-defined']) {
             $componentType = $filters['comp-filters'][0]['name'];
 
             // Checking if we need post-filters
@@ -530,7 +530,7 @@ class Mongo extends \Sabre\CalDAV\Backend\AbstractBackend implements
                 $requirePostFilter = false;
             }
             // There was a time-range filter
-            if ($componentType == 'VEVENT' && isset($filters['comp-filters'][0]['time-range']) && is_array($filters['comp-filters'][0]['time-range'])) {
+            if ($componentType == 'VEVENT' && is_array($filters['comp-filters'][0]['time-range'])) {
                 $timeRange = $filters['comp-filters'][0]['time-range'];
 
                 // If start time OR the end time is not specified, we can do a

--- a/lib/CalDAV/Backend/Mongo.php
+++ b/lib/CalDAV/Backend/Mongo.php
@@ -517,25 +517,25 @@ class Mongo extends \Sabre\CalDAV\Backend\AbstractBackend implements
         $timeRange = null;
 
         // if no filters were specified, we don't need to filter after a query
-        if (!$filters['prop-filters'] && !$filters['comp-filters']) {
+        if (empty($filters['prop-filters']) && empty($filters['comp-filters'])) {
             $requirePostFilter = false;
         }
 
         // Figuring out if there's a component filter
-        if (count($filters['comp-filters']) > 0 && !$filters['comp-filters'][0]['is-not-defined']) {
+        if (!empty($filters['comp-filters']) && is_array($filters['comp-filters']) && count($filters['comp-filters']) > 0 && !$filters['comp-filters'][0]['is-not-defined']) {
             $componentType = $filters['comp-filters'][0]['name'];
 
             // Checking if we need post-filters
-            if (!$filters['prop-filters'] && !$filters['comp-filters'][0]['comp-filters'] && !$filters['comp-filters'][0]['time-range'] && !$filters['comp-filters'][0]['prop-filters']) {
+            if (empty($filters['prop-filters']) && empty($filters['comp-filters'][0]['comp-filters']) && empty($filters['comp-filters'][0]['time-range']) && empty($filters['comp-filters'][0]['prop-filters'])) {
                 $requirePostFilter = false;
             }
             // There was a time-range filter
-            if ($componentType == 'VEVENT' && isset($filters['comp-filters'][0]['time-range'])) {
+            if ($componentType == 'VEVENT' && isset($filters['comp-filters'][0]['time-range']) && is_array($filters['comp-filters'][0]['time-range'])) {
                 $timeRange = $filters['comp-filters'][0]['time-range'];
 
                 // If start time OR the end time is not specified, we can do a
                 // 100% accurate mysql query.
-                if (!$filters['prop-filters'] && !$filters['comp-filters'][0]['comp-filters'] && !$filters['comp-filters'][0]['prop-filters'] && (!$timeRange['start'] || !$timeRange['end'])) {
+                if (empty($filters['prop-filters']) && empty($filters['comp-filters'][0]['comp-filters']) && empty($filters['comp-filters'][0]['prop-filters']) && (empty($timeRange['start']) || empty($timeRange['end']))) {
                     $requirePostFilter = false;
                 }
             }

--- a/tests/CalDAV/Backend/AbstractDatabaseTest.php
+++ b/tests/CalDAV/Backend/AbstractDatabaseTest.php
@@ -443,6 +443,83 @@ abstract class AbstractDatabaseTest extends \PHPUnit_Framework_TestCase {
         ), $backend->calendarQuery($id, $filters));
     }
 
+    /**
+     * Test calendarQuery with boolean filter values (issue #188)
+     *
+     * This test ensures that calendarQuery handles filters with boolean values
+     * instead of arrays without throwing "Trying to access array offset on
+     * value of type bool" errors.
+     *
+     * When XML parsing returns false for missing filter properties, the method
+     * should handle these gracefully rather than attempting to access them as arrays.
+     */
+    function testCalendarQueryWithBooleanFilters() {
+        $id = $this->generateId();
+
+        $backend = $this->getBackend();
+        $backend->createCalendarObject($id, "event", "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nDTSTART:20120101\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n");
+        $backend->createCalendarObject($id, "todo", "BEGIN:VCALENDAR\r\nBEGIN:VTODO\r\nEND:VTODO\r\nEND:VCALENDAR\r\n");
+
+        // Test case 1: Filters with boolean false values (simulating XML parsing behavior)
+        $filters = array(
+            'name' => 'VCALENDAR',
+            'comp-filters' => false,
+            'prop-filters' => false,
+            'is-not-defined' => false,
+            'time-range' => null,
+        );
+
+        $result = $backend->calendarQuery($id, $filters);
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+        $this->assertTrue(in_array('event', $result));
+        $this->assertTrue(in_array('todo', $result));
+
+        // Test case 2: Filters with VEVENT comp-filter containing boolean sub-filters
+        $filters = array(
+            'name' => 'VCALENDAR',
+            'comp-filters' => array(
+                array(
+                    'name' => 'VEVENT',
+                    'comp-filters' => false,
+                    'prop-filters' => false,
+                    'is-not-defined' => false,
+                    'time-range' => false,
+                ),
+            ),
+            'prop-filters' => false,
+            'is-not-defined' => false,
+            'time-range' => null,
+        );
+
+        $result = $backend->calendarQuery($id, $filters);
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
+        $this->assertTrue(in_array('event', $result));
+
+        // Test case 3: Filters with empty arrays (normal case, should still work)
+        $filters = array(
+            'name' => 'VCALENDAR',
+            'comp-filters' => array(
+                array(
+                    'name' => 'VEVENT',
+                    'comp-filters' => array(),
+                    'prop-filters' => array(),
+                    'is-not-defined' => false,
+                    'time-range' => array(),
+                ),
+            ),
+            'prop-filters' => array(),
+            'is-not-defined' => false,
+            'time-range' => null,
+        );
+
+        $result = $backend->calendarQuery($id, $filters);
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
+        $this->assertTrue(in_array('event', $result));
+    }
+
     function testGetChanges() {
         $backend = $this->getBackend();
         $id = $backend->createCalendar(

--- a/tests/CalDAV/Backend/AbstractDatabaseTest.php
+++ b/tests/CalDAV/Backend/AbstractDatabaseTest.php
@@ -470,7 +470,7 @@ abstract class AbstractDatabaseTest extends \PHPUnit_Framework_TestCase {
         );
 
         $result = $backend->calendarQuery($id, $filters);
-        $this->assertIsArray($result);
+        $this->assertTrue(is_array($result));
         $this->assertCount(2, $result);
         $this->assertTrue(in_array('event', $result));
         $this->assertTrue(in_array('todo', $result));
@@ -493,7 +493,7 @@ abstract class AbstractDatabaseTest extends \PHPUnit_Framework_TestCase {
         );
 
         $result = $backend->calendarQuery($id, $filters);
-        $this->assertIsArray($result);
+        $this->assertTrue(is_array($result));
         $this->assertCount(1, $result);
         $this->assertTrue(in_array('event', $result));
 
@@ -515,7 +515,7 @@ abstract class AbstractDatabaseTest extends \PHPUnit_Framework_TestCase {
         );
 
         $result = $backend->calendarQuery($id, $filters);
-        $this->assertIsArray($result);
+        $this->assertTrue(is_array($result));
         $this->assertCount(1, $result);
         $this->assertTrue(in_array('event', $result));
     }


### PR DESCRIPTION
## Summary
Fix regression where REPORT requests on calendar endpoints fail with "Trying to access array offset on value of type bool" error.

## Problem
The `calendarQuery` method in `Mongo.php` was accessing filter array indices without first checking if the filter values were arrays or booleans. When XML parsing returns `false` for missing filter properties, accessing them as arrays causes PHP 7.4+ to throw errors.

## Solution
- Replace `!$filters['prop-filters']` with `empty($filters['prop-filters'])`
- Add `is_array()` checks before accessing array indices on comp-filters
- Add `is_array()` checks before accessing time-range array indices
- Use `empty()` instead of `!` to safely handle both false and empty arrays

This follows the same fix pattern applied in SabreDAV 4.1.4 (issues #1319, #1321).

## Changes
- **lib/CalDAV/Backend/Mongo.php**: Fix array offset access on boolean values
- **tests/CalDAV/Backend/AbstractDatabaseTest.php**: Add comprehensive test covering 3 scenarios:
  1. Filters with boolean false values (simulating XML parsing behavior)
  2. VEVENT comp-filter with boolean sub-filters
  3. Empty arrays (normal case for regression testing)

## Test plan
- [x] New test `testCalendarQueryWithBooleanFilters` validates the fix
- [x] All existing calendarQuery tests should still pass
- [x] Manual test with the curl command from issue #188 should succeed

Fixes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)