### PR TITLE
fix(nginx): correct fastcgi_pass socket path to match PHP-FPM configuration

### DIFF
--- a/docker/config/nginx.conf
+++ b/docker/config/nginx.conf
@@ -22,7 +22,7 @@ server {
         return 200;
     }
 
-    fastcgi_pass unix:/var/run/php/php7.4-fpm.sock;
+    fastcgi_pass unix:/var/run/php/php-fpm.sock;
     include fastcgi_params;
     fastcgi_param SCRIPT_FILENAME /var/www/esn.php;
     fastcgi_read_timeout 120s;


### PR DESCRIPTION
The Nginx config was previously pointing to `/var/run/php/php7.4-fpm.sock`,
while PHP-FPM was configured to listen on `/var/run/php/php-fpm.sock`.
This mismatch caused Nginx to return `502 Bad Gateway` errors because
the socket file did not exist.

Ref: aeb3ac288375e4093147b57ce172ce3db87011b1
