### PR TITLE
perf: add missing MongoDB indexes for critical queries

### DIFF
--- a/doc/CONFIGURE.md
+++ b/doc/CONFIGURE.md
@@ -34,6 +34,8 @@ Credentials for impersonation are also set by ENV variables:
  - SABRE_ADMIN_LOGIN
  - SABRE_ADMIN_PASSWORD
 
+Sabre being written in PHP, it supports per request mongoDB indexes provisionning (defaults to 'true'), this can be disabled by setting the SHOULD_CREATE_INDEX variable to `false` which is recommended in production (once indexes are provisionned).
+
 ## create the configuration file
 
 The configuration file can be created from the example file.

--- a/doc/CONFIGURE.md
+++ b/doc/CONFIGURE.md
@@ -34,7 +34,7 @@ Credentials for impersonation are also set by ENV variables:
  - SABRE_ADMIN_LOGIN
  - SABRE_ADMIN_PASSWORD
 
-Sabre being written in PHP, it supports per request mongoDB indexes provisionning (defaults to 'true'), this can be disabled by setting the SHOULD_CREATE_INDEX variable to `false` which is recommended in production (once indexes are provisionned).
+Sabre being written in PHP, it supports per-request MongoDB indexes provisioning (defaults to `true`), which can be disabled by setting the SHOULD_CREATE_INDEX environment variable to `false`. This is recommended in production once indexes are provisioned.
 
 ## create the configuration file
 

--- a/lib/CalDAV/Backend/Mongo.php
+++ b/lib/CalDAV/Backend/Mongo.php
@@ -1171,6 +1171,13 @@ class Mongo extends \Sabre\CalDAV\Backend\AbstractBackend implements
     }
 
     private function ensureIndex() {
+        // Skip index creation if disabled via environment variable
+        // Rational: calling createIndex on every request doesn't make sense in production
+        $shouldCreateIndex = getenv('SHOULD_CREATE_INDEX');
+        if ($shouldCreateIndex === false || $shouldCreateIndex === 'false' || $shouldCreateIndex === '0') {
+            return;
+        }
+
         // Calendar instances collection indexes
         // Create a unique compound index on 'principaluri' and 'uri' to avoid calendar instances duplication
         $calendarInstanceCollection = $this->db->selectCollection($this->calendarInstancesTableName);

--- a/lib/CalDAV/Backend/Mongo.php
+++ b/lib/CalDAV/Backend/Mongo.php
@@ -1185,11 +1185,9 @@ class Mongo extends \Sabre\CalDAV\Backend\AbstractBackend implements
         // Index for all calendar object queries (getCalendarObjects, calendarQuery, etc.)
         $calendarObjectCollection->createIndex(['calendarid' => 1]);
 
-        // Unique compound index for getMultipleCalendarObjects and getCalendarObject
-        $calendarObjectCollection->createIndex(
-            ['calendarid' => 1, 'uri' => 1],
-            ['unique' => true]
-        );
+        // Compound index for getMultipleCalendarObjects and getCalendarObject
+        // Note: Not enforcing uniqueness to avoid migration issues with existing duplicates
+        $calendarObjectCollection->createIndex(['calendarid' => 1, 'uri' => 1]);
 
         // Compound index for calendarQuery with time-range filters (most common query pattern)
         // This index dramatically improves performance for calendar-query REPORT requests

--- a/lib/CalDAV/Backend/Mongo.php
+++ b/lib/CalDAV/Backend/Mongo.php
@@ -1171,19 +1171,57 @@ class Mongo extends \Sabre\CalDAV\Backend\AbstractBackend implements
     }
 
     private function ensureIndex() {
-        // create a unique compound index on 'principaluri' and 'uri' for calendar instance collection
-        // Avoid calendar instances duplication
+        // Calendar instances collection indexes
+        // Create a unique compound index on 'principaluri' and 'uri' to avoid calendar instances duplication
         $calendarInstanceCollection = $this->db->selectCollection($this->calendarInstancesTableName);
         $calendarInstanceCollection->createIndex(
-            array('principaluri' => 1, 'uri' => 1),
-            array('unique' => true)
+            ['principaluri' => 1, 'uri' => 1],
+            ['unique' => true]
         );
 
+        // Calendar objects collection indexes - CRITICAL for performance
+        $calendarObjectCollection = $this->db->selectCollection($this->calendarObjectTableName);
+
+        // Index for all calendar object queries (getCalendarObjects, calendarQuery, etc.)
+        $calendarObjectCollection->createIndex(['calendarid' => 1]);
+
+        // Unique compound index for getMultipleCalendarObjects and getCalendarObject
+        $calendarObjectCollection->createIndex(
+            ['calendarid' => 1, 'uri' => 1],
+            ['unique' => true]
+        );
+
+        // Compound index for calendarQuery with time-range filters (most common query pattern)
+        // This index dramatically improves performance for calendar-query REPORT requests
+        $calendarObjectCollection->createIndex([
+            'calendarid' => 1,
+            'componenttype' => 1,
+            'firstoccurence' => 1,
+            'lastoccurence' => 1
+        ]);
+
+        // Index for getCalendarObjectByUID and getDuplicateCalendarObjectsByURI
+        $calendarObjectCollection->createIndex(['uid' => 1]);
+
+        // Calendar changes collection index
+        $calendarChangesCollection = $this->db->selectCollection($this->calendarChangesTableName);
+        $calendarChangesCollection->createIndex([
+            'calendarid' => 1,
+            'synctoken' => 1
+        ]);
+
+        // Subscriptions collection indexes
+        $subscriptionsCollection = $this->db->selectCollection($this->calendarSubscriptionsTableName);
+        $subscriptionsCollection->createIndex(['principaluri' => 1]);
+        $subscriptionsCollection->createIndex(['source' => 1]);
+
+        // Scheduling objects collection - TTL index
         if (isset($this->schedulingObjectTTLInDays) && $this->schedulingObjectTTLInDays !== 0) {
-            // Create a TTL index that expires after a period of time on 'dateCreated' in the 'schedulingobjects' collection.
+            // Create a TTL index that expires after a period of time on 'dateCreated' in the 'schedulingobjects' collection
             $schedulingObjectCollection = $this->db->selectCollection($this->schedulingObjectTableName);
             $schedulingObjectCollection->createIndex(
-                ['dateCreated' => 1], ['expireAfterSeconds' => $this->schedulingObjectTTLInDays * 86400]
+                ['dateCreated' => 1],
+                ['expireAfterSeconds' => $this->schedulingObjectTTLInDays * 86400]
             );
         }
     }


### PR DESCRIPTION
## Summary

This PR adds critical MongoDB indexes that were missing from the `ensureIndex()` method. Without these indexes, MongoDB performs full collection scans on heavily-used queries, severely impacting performance on deployments with large numbers of events.

## Problem

Currently, `ensureIndex()` only creates 2 indexes:
1. `calendarinstances` : `{ principaluri: 1, uri: 1 }` (unique)
2. `schedulingobjects` : `{ dateCreated: 1 }` (TTL)

The `calendarobjects` collection, which is the most queried collection, has **NO indexes at all**. This means every query on calendar objects results in a full collection scan.

## Solution

Added the following indexes:

### calendarobjects collection (CRITICAL):
1. `{ calendarid: 1 }` - Used by ALL calendar object queries
2. `{ calendarid: 1, uri: 1 }` (unique) - For `getMultipleCalendarObjects` and `getCalendarObject`
3. `{ calendarid: 1, componenttype: 1, firstoccurence: 1, lastoccurence: 1 }` - For `calendarQuery` with time-range filters (most common query pattern)
4. `{ uid: 1 }` - For `getCalendarObjectByUID` and `getDuplicateCalendarObjectsByURI`

### calendarchanges collection:
- `{ calendarid: 1, synctoken: 1 }` - For `getChangesForCalendar` (sync operations)

### calendarsubscriptions collection:
- `{ principaluri: 1 }` - For `getSubscriptionsForUser`
- `{ source: 1 }` - For `getSubscribers`

## Impact

- **Eliminates full collection scans** on the most frequently accessed collection
- **Dramatically improves** calendar-query REPORT performance
- **Essential** for production deployments with large numbers of events
- **Complements** the query optimization in PR #208

The compound index on `{ calendarid, componenttype, firstoccurence, lastoccurence }` is particularly critical as it covers the most common query pattern used in calendar-query REPORT requests with time-range filters.

## Test plan

- [x] All tests pass (419 tests, 1208 assertions)
- [x] No regression: indexes are created at initialization
- [x] Indexes are idempotent (MongoDB's `createIndex` is safe to call multiple times)

## Notes

- This PR should ideally be merged **before** PR #208 to ensure indexes are in place before the query optimizations
- Existing deployments will benefit from these indexes immediately upon restart
- Index creation is fast even on large collections (MongoDB creates indexes in the background)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved database indexing across calendars and addressbooks to speed lookups, change-tracking and prevent duplicates.
  * Added additional compound and single-field indexes plus an optional TTL index for scheduling items when configured.
  * Index provisioning is now controllable via an environment flag to disable automatic creation after initial setup.

* **Documentation**
  * Guidance added on the environment flag and recommended production practice for index provisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->