### PR TITLE
fix: bypass Docker build: composer security advisory for firebase/php-jwt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,6 @@ COPY . /var/www
 # Install dependencies without dev packages (using install to respect composer.lock)
 RUN git config --global --add safe.directory '/var/www/vendor/sabre/vobject' && \
     composer clearcache && \
-    composer config --global audit.ignore 'PKSA-2kqm-ps5x-s4f5' && \
     composer install --no-dev --optimize-autoloader --no-interaction && \
     # Clean up composer cache and remove git
     rm -rf /root/.composer/cache && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,7 @@ COPY . /var/www
 # Install dependencies without dev packages (using install to respect composer.lock)
 RUN git config --global --add safe.directory '/var/www/vendor/sabre/vobject' && \
     composer clearcache && \
+    composer config --global audit.ignore 'PKSA-2kqm-ps5x-s4f5' && \
     composer install --no-dev --optimize-autoloader --no-interaction && \
     # Clean up composer cache and remove git
     rm -rf /root/.composer/cache && \

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "sabre/vobject": "dev-waiting-merges-4.2.2 as 4.2.2",
         "mongodb/mongodb": "^1.15",
         "monolog/monolog": "^2.9",
-        "firebase/php-jwt": "5.5.1"
+        "firebase/php-jwt": "^6.0"
     },
     "require-dev" : {
         "phpunit/phpunit" : "^9.0",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "sabre/vobject": "dev-waiting-merges-4.2.2 as 4.2.2",
         "mongodb/mongodb": "^1.15",
         "monolog/monolog": "^2.9",
-        "firebase/php-jwt": "5.2.0"
+        "firebase/php-jwt": "5.5.1"
     },
     "require-dev" : {
         "phpunit/phpunit" : "^9.0",

--- a/lib/DAV/Auth/Backend/Esn.php
+++ b/lib/DAV/Auth/Backend/Esn.php
@@ -6,6 +6,7 @@ use \Sabre\DAV;
 use \Sabre\HTTP;
 use Sabre\Event\EventEmitter;
 use \Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 
 define('ESN_PUBLIC_KEY', __DIR__ . '/../../../../config/esn.key.pub');
 
@@ -258,7 +259,7 @@ class Esn extends \Sabre\DAV\Auth\Backend\AbstractBasic {
 
             try {
                 // Try to decode the token with the public key
-                $user = JWT::decode($token, $key, array('RS256'));
+                $user = JWT::decode($token, new Key($key, 'RS256'));
 
                 // Get the user Id associated with the identifier of the token ( email in sub field )
                 $principleId = $this->principalBackend->getPrincipalIdByEmail($user->sub);


### PR DESCRIPTION
This PR fixes the Docker build failure caused by Composer blocking the installation of `firebase/php-jwt` 5.x due to a security advisory (PKSA-2kqm-ps5x-s4f5).
[CI ](https://james-jenkins.lin-saas.com/blue/organizations/jenkins/ESN%20Sabre%20build/detail/sabre-4_1_5-14-11-2025/5/pipeline/)
```
5.478     - Root composer.json requires firebase/php-jwt 5.2.0 (exact version match: 5.2.0 or 5.2.0.0), found firebase/php-jwt[v5.2.0] but these were not loaded, because they are affected by security advisories. To ignore the advisories, add ("PKSA-2kqm-ps5x-s4f5") to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.
```

The ESN-Sabre master is locked to PHP 7.4, which only supports php-jwt 5.x. However, since composer.lock is intentionally ignored upstream, Composer performs an update during Docker build and triggers the security audit, causing the installation to fail.

- This safely ignores *only* the firebase/php-jwt advisory for this build environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated JWT authentication library to version 6 and adjusted server-side JWT handling for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->