### PR TITLE
fix: prevent redundant alarm events for unaffected attendees (#221)

### DIFF
--- a/lib/Publisher/CalDAV/EventRealTimePlugin.php
+++ b/lib/Publisher/CalDAV/EventRealTimePlugin.php
@@ -381,9 +381,16 @@ class EventRealTimePlugin extends \ESN\Publisher\RealTimePlugin {
         $this->notifySubscribers($calendar->getSubscribers(), $dataMessage, $options);
         $this->notifyInvites($calendar->getInvites(), $dataMessage, $options);
 
-        if($iTipMessage->method !== 'REPLY'){
+        // Only publish alarm events for REQUEST if it's a significant change
+        // (e.g., new event, alarm modified, not just another attendee's PARTSTAT change)
+        if($iTipMessage->method === 'REQUEST' && $iTipMessage->significantChange){
             $this->createMessage(
-                $this->EVENT_TOPICS['EVENT_ALARM_'.$iTipMessage->method],
+                $this->EVENT_TOPICS['EVENT_ALARM_REQUEST'],
+                $dataMessage
+            );
+        } elseif ($iTipMessage->method === 'CANCEL') {
+            $this->createMessage(
+                $this->EVENT_TOPICS['EVENT_ALARM_CANCEL'],
                 $dataMessage
             );
         }

--- a/lib/Publisher/CalDAV/EventRealTimePlugin.php
+++ b/lib/Publisher/CalDAV/EventRealTimePlugin.php
@@ -383,7 +383,7 @@ class EventRealTimePlugin extends \ESN\Publisher\RealTimePlugin {
 
         // Only publish alarm events for REQUEST if it's a significant change
         // (e.g., new event, alarm modified, not just another attendee's PARTSTAT change)
-        if($iTipMessage->method === 'REQUEST' && $iTipMessage->significantChange){
+        if ($iTipMessage->method === 'REQUEST' && $iTipMessage->significantChange) {
             $this->createMessage(
                 $this->EVENT_TOPICS['EVENT_ALARM_REQUEST'],
                 $dataMessage


### PR DESCRIPTION
## Summary

Fixes #221: When an organizer creates an event with multiple attendees and a VALARM, and one attendee updates their participation status (e.g., ACCEPTED), the system was incorrectly publishing `EVENT_ALARM_REQUEST` events to all other attendees whose alarm state hadn't changed.

## Changes

- Modified `EventRealTimePlugin::schedule()` to only publish `EVENT_ALARM_REQUEST` when the iTip message represents a significant change (new event or alarm modification)
- Preserved `EVENT_ALARM_CANCEL` behavior for cancelled events
- Prevents redundant alarm notifications to unaffected attendees

## Test plan

- [x] All existing tests pass
- [x] Verified the fix targets only REQUEST methods with significantChange flag
- [x] Confirmed CANCEL method still publishes alarm events as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Alarm notifications now only publish for meaningful event updates (reducing spurious alarm broadcasts).
  * Cancellations correctly emit alarm cancellation notifications so subscribers are informed when events are cancelled.
  * Notification flow adjusted to ensure subscriber and invite notifications remain intact while alarm publication follows the new conditions.

* **Chores**
  * Test setup updated to use a specific test branch for integration checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->