### PR TITLE
Fix #50: YEARLY RRULE with BYMONTH returns wrong first occurrence

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -95,14 +95,10 @@ RUN cp -v docker/prepare/set_nginx_htpasswd.sh /root/set_nginx_htpasswd.sh \
     && /root/set_nginx_htpasswd.sh \
     && mkdir -p /var/run/php
 
-# Install dependencies without dev packages (using install to respect composer.lock)
+# Install dependencies
 RUN git config --global --add safe.directory '/var/www/vendor/sabre/vobject' && \
     composer clearcache && \
-    composer install --no-dev --optimize-autoloader --no-interaction
-
-RUN git config --global --add safe.directory '/var/www/vendor/sabre/vobject'
-
-RUN composer clearcache && composer update --dev
+    composer update --optimize-autoloader --no-interaction
 
 EXPOSE 80
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php-amqplib/php-amqplib": "^3.3",
         "php": ">=8.4",
         "sabre/dav": "4.7.0",
-	"sabre/vobject": "dev-linagora-waiting-merges-4.5#da71270578247927ee26c9a7d96ec3d48b6b8783 as 4.5.7",
+        "sabre/vobject": "dev-linagora-waiting-merges-4.5#df65b241c18c4c08cca31fb4dc71b82d231dfc06 as 4.5.7",
         "mongodb/mongodb": "^2.4",
         "monolog/monolog": "^2.9",
         "firebase/php-jwt": "^6.10"


### PR DESCRIPTION
## Summary

Fix for issue #50: REPORT API returns incorrect data for `RRULE:FREQ=YEARLY;BYMONTH=5;BYMONTHDAY=15`

## Problem

When an event has:
- **DTSTART**: April 11, 2030 (Asia/Ho_Chi_Minh timezone)
- **RRULE**: `FREQ=YEARLY;BYMONTH=5;BYMONTHDAY=15`

The calendar query incorrectly returned an occurrence in **April** instead of **May**. The first valid occurrence should be **May 15, 2030**.

## Root Cause

The bug was in `sabre-vobject`'s `RRuleIterator::rewind()` method. When DTSTART is not in a month specified by BYMONTH, the iterator was still returning DTSTART as the first occurrence instead of advancing to the first valid date.

## Fix

- Updated `sabre-vobject` fork with a fix in `RRuleIterator::rewind()` to check if DTSTART is valid according to BYMONTH rules
- Added regression test in `RecurrenceExpansionTest.php`

## Test Plan

- [x] New test `testYearlyWithBYMONTHAndBYMONTHDAYDifferentFromDTSTART` passes
- [x] All existing tests still pass

Fixes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for calendar recurrence expansion to validate yearly rules combining BYMONTH and BYMONTHDAY edge cases.

* **Chores**
  * Simplified dependency installation in the test Docker build.
  * Updated an internal library reference while preserving the same public version tag.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->