### PR TITLE
Revert "ISSUE-235 Bob invites alice: avoid double messages to exchange calendar:event:request"

### DIFF
--- a/lib/Publisher/CalDAV/EventRealTimePlugin.php
+++ b/lib/Publisher/CalDAV/EventRealTimePlugin.php
@@ -385,6 +385,7 @@ class EventRealTimePlugin extends \ESN\Publisher\RealTimePlugin {
         ];
 
         $this->notifySubscribers($calendar->getSubscribers(), $dataMessage, $options);
+        $this->notifyInvites($calendar->getInvites(), $dataMessage, $options);
 
         // Only publish alarm events for REQUEST if it's a significant change
         // (e.g., new event, alarm modified, not just another attendee's PARTSTAT change)


### PR DESCRIPTION
If needed...

Reverts linagora/esn-sabre#236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where scheduled calendar events were not sending notifications to all event invitees. Invitees now receive notifications consistently with other subscribers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->