### PR TITLE
ISSUE-1144 auth: control admin impersonation via SABRE_IMPERSONATION_ENABLED flag

### DIFF
--- a/doc/CONFIGURE.md
+++ b/doc/CONFIGURE.md
@@ -34,6 +34,14 @@ Credentials for impersonation are also set by ENV variables:
  - SABRE_ADMIN_LOGIN
  - SABRE_ADMIN_PASSWORD
 
+Feature flag to enable or disable admin impersonation.
+ - SABRE_IMPERSONATION_ENABLED
+
+   - `true`  : enable impersonation (internal / non-public Sabre only)
+   - `false` : disable impersonation (default, recommended for public Sabre)
+   This flag allows disabling admin impersonation entirely on public Sabre deployments
+   to prevent impersonation over the internet.
+
 Sabre being written in PHP, it supports per-request MongoDB indexes provisioning (defaults to `true`), which can be disabled by setting the SHOULD_CREATE_INDEX environment variable to `false`. This is recommended in production once indexes are provisioned.
 
 ## create the configuration file

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -117,6 +117,9 @@ This plugin handle:
  - Basic auth via impersonation using `SABRE_ADMIN_LOGIN` and `SABRE_ADMIN_PASSWORD` variables following the 
  `{SABRE_ADMIN_LOGIN}&{username}:{SABRE_ADMIN_PASSWORD}` pattern.
   Please note that the Side service leverage this impersonation to expose an OpenID connect authenticated endpoint that proxies requests to Sabre.
+- Admin impersonation is controlled by the `SABRE_IMPERSONATION_ENABLED` environment variable:
+  - `true`  : enable impersonation (internal / non-public Sabre only)
+  - `false` : disable impersonation (default, recommended for public Sabre)
  - Basic auth against a LDAP. The authentication result (mail address) is then consolidated agsainst the side service in order
  to retieve the corresponding principalId.
  - Authentication via JWT token, which is still relied upon by legacy OpenPaaS SPAs (deprecated). This token can be generated on the side


### PR DESCRIPTION
Admin impersonation is now explicitly controlled by the SABRE_IMPERSONATION_ENABLED environment variable.

When disabled, the impersonation code path is skipped entirely, preventing admin impersonation on publicly exposed Sabre instances.

This aligns with the security hardening goal of disabling impersonation over the internet.