### PR TITLE
ISSUE-242 IMIP should fallback to event owner when no organizer

### DIFF
--- a/lib/Utils/Utils.php
+++ b/lib/Utils/Utils.php
@@ -58,6 +58,12 @@ class Utils {
     }
 
     static function getPrincipalByUri($uri, \Sabre\DAV\Server $server) {
+        // Issue #242: Handle null or empty URI to prevent TypeError in substr()
+        if ($uri === null || $uri === '') {
+            error_log('3.7;getPrincipalByUri called with null or empty URI.');
+            return;
+        }
+
         $aclPlugin = $server->getPlugin('acl');
 
         if (!$aclPlugin) {

--- a/tests/Utils/UtilsTest.php
+++ b/tests/Utils/UtilsTest.php
@@ -168,6 +168,32 @@ ICS;
     }
 
     /**
+     * Test for issue #242 - Handle null URI in getPrincipalByUri
+     *
+     * When deleting a calendar event, if the iTipMessage recipient is null,
+     * getPrincipalByUri should handle it gracefully instead of causing a
+     * TypeError in substr().
+     */
+    function testGetPrincipalByUriWithNullUri() {
+        // This should not throw a TypeError
+        $result = Utils::getPrincipalByUri(null, $this->server);
+
+        // Should return null when URI is null
+        $this->assertNull($result);
+    }
+
+    /**
+     * Test for issue #242 - Handle empty string URI in getPrincipalByUri
+     */
+    function testGetPrincipalByUriWithEmptyUri() {
+        // This should not throw a TypeError
+        $result = Utils::getPrincipalByUri('', $this->server);
+
+        // Should return null when URI is empty
+        $this->assertNull($result);
+    }
+
+    /**
      * Test for issue #43 - Non-standard timezone IDs from Microsoft Exchange
      *
      * This test verifies that calendar events with non-standard timezone identifiers


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of calendar events with missing organizer information to prevent processing errors.
  * Added validation for invalid calendar identifiers to ensure robust request handling.

* **Tests**
  * Added test coverage for calendar event edge cases and identifier validation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->