### PR TITLE
Implement CARD DAV sharing

### DIFF
--- a/lib/CardDAV/Backend/Mongo.php
+++ b/lib/CardDAV/Backend/Mongo.php
@@ -474,6 +474,14 @@ class Mongo extends \Sabre\CardDAV\Backend\AbstractBackend implements
 
         $subscriptions = [];
         foreach ($res as $row) {
+            // Get privilege field
+            $privilege = $this->getValue($row, 'privilege', ['dav:read']);
+
+            // Convert MongoDB BSONArray to PHP array if needed
+            if ($privilege instanceof \MongoDB\Model\BSONArray) {
+                $privilege = $privilege->getArrayCopy();
+            }
+
             $subscription = [
                 'id'           => (string)$row['_id'],
                 '{DAV:}displayname' => $row['displayname'],
@@ -481,8 +489,9 @@ class Mongo extends \Sabre\CardDAV\Backend\AbstractBackend implements
                 'principaluri' => $row['principaluri'],
                 '{http://open-paas.org/contacts}subscription-type' => 'public',
                 '{http://open-paas.org/contacts}source' => $row['source'],
+                'source'       => $row['source'],
                 'lastmodified' => $row['lastmodified'],
-                '{DAV:}acl'    => $this->getValue($row, 'privilege', ['dav:read', 'dav:write']),
+                '{DAV:}acl'    => $privilege,
                 '{' . \Sabre\CardDAV\Plugin::NS_CARDDAV . '}addressbook-description' => $this->getValue($row, 'description', '')
             ];
 
@@ -502,7 +511,7 @@ class Mongo extends \Sabre\CardDAV\Backend\AbstractBackend implements
             'description'  => '',
             'principaluri' => $principalUri,
             'uri'          => $uri,
-            'privilege' => ['dav:read', 'dav:write'],
+            'privilege' => ['dav:read'],
             'source'       => $properties['{http://open-paas.org/contacts}source']->getHref(),
             'lastmodified' => time(),
         ];

--- a/lib/CardDAV/Sharing/SharedAddressBook.php
+++ b/lib/CardDAV/Sharing/SharedAddressBook.php
@@ -325,4 +325,16 @@ class SharedAddressBook extends \Sabre\CardDAV\AddressBook implements \ESN\DAV\I
     function setPublishStatus($value) {
         throw new DAV\Exception\MethodNotAllowed('You are not allowed to publish a shared address book');
     }
+
+    /**
+     * Returns the list of subscribers (addressbook) of this shared addressbook.
+     *
+     * A shared addressbook itself doesn't have subscribers in the subscription sense.
+     * This method exists to satisfy the interface expected by plugins.
+     *
+     * @return array Empty array (shared addressbooks don't have their own subscribers)
+     */
+    function getSubscribedAddressBooks() {
+        return [];
+    }
 }

--- a/lib/CardDAV/Subscriptions/Subscription.php
+++ b/lib/CardDAV/Subscriptions/Subscription.php
@@ -3,6 +3,8 @@
 namespace ESN\CardDAV\Subscriptions;
 
 use ESN\CardDAV\Backend\SubscriptionSupport;
+use ESN\DAV\Sharing\Plugin as SPlugin;
+use ESN\Utils\Utils;
 use Sabre\DAV\Collection;
 use Sabre\DAV\PropPatch;
 use Sabre\DAV\Xml\Property\Href;
@@ -92,6 +94,8 @@ class Subscription extends Collection implements ISubscription, IACL {
      * @return void
      */
     function delete() {
+        // Check unbind privilege before deleting
+        $this->checkDeleteAccess();
 
         $this->carddavBackend->deleteSubscription(
             $this->subscriptionInfo['id']
@@ -105,9 +109,257 @@ class Subscription extends Collection implements ISubscription, IACL {
      * @return \Sabre\DAV\INode[]
      */
     function getChildren() {
+        // Get cards from the source address book
+        $sourceAddressBookInfo = $this->getSourceAddressBookInfo();
+        if (!$sourceAddressBookInfo) {
+            return [];
+        }
 
+        $objs = $this->carddavBackend->getCards($sourceAddressBookInfo['id']);
+        $children = [];
+
+        foreach($objs as $obj) {
+            $obj = (array) $obj; // Convert BSONDocument to array
+            $obj['acl'] = $this->getChildACL();
+            $children[] = new SubscriptionCard($this->carddavBackend, $sourceAddressBookInfo, $obj, $this);
+        }
+        return $children;
+    }
+
+    /**
+     * Returns a single child node by name
+     *
+     * @param string $name
+     * @return \Sabre\DAV\INode
+     */
+    function getChild($name) {
+        $sourceAddressBookInfo = $this->getSourceAddressBookInfo();
+        if (!$sourceAddressBookInfo) {
+            throw new \Sabre\DAV\Exception\NotFound('Card not found');
+        }
+
+        $obj = $this->carddavBackend->getCard($sourceAddressBookInfo['id'], $name);
+        if (!$obj) {
+            throw new \Sabre\DAV\Exception\NotFound('Card not found');
+        }
+        $obj = (array) $obj; // Convert BSONDocument to array
+        $obj['acl'] = $this->getChildACL();
+
+        return new SubscriptionCard($this->carddavBackend, $sourceAddressBookInfo, $obj, $this);
+    }
+
+    /**
+     * Creates a new file in the directory
+     *
+     * Data will either be supplied as a stream resource, or in certain cases
+     * as a string. Keep in mind that you may have to support either.
+     *
+     * After successful creation of the file, you may choose to return the ETag
+     * of the new file here.
+     *
+     * @param string $name Name of the file
+     * @param resource|string $vcardData Initial payload
+     * @return string|null
+     */
+    function createFile($name, $vcardData = null) {
+        // Check write access before creating
+        $this->checkWriteAccess();
+
+        if (is_resource($vcardData)) {
+            $vcardData = stream_get_contents($vcardData);
+        }
+        // Converting to UTF-8, if needed
+        $vcardData = \Sabre\DAV\StringUtil::ensureUTF8($vcardData);
+
+        // Create the card in the source address book
+        $sourceAddressBookInfo = $this->getSourceAddressBookInfo();
+        if (!$sourceAddressBookInfo) {
+            throw new \Sabre\DAV\Exception\Forbidden('Cannot create card: source address book not found');
+        }
+
+        return $this->carddavBackend->createCard($sourceAddressBookInfo['id'], $name, $vcardData);
+    }
+
+    /**
+     * Returns address book info for the source address book that this subscription points to.
+     * This is used when creating/updating/deleting Card objects so that operations
+     * are performed on the source address book instead of the subscription.
+     *
+     * @return array|null
+     */
+    protected function getSourceAddressBookInfo() {
+        $sourceKey = '{http://open-paas.org/contacts}source';
+        if (!isset($this->subscriptionInfo[$sourceKey])) {
+            return null;
+        }
+
+        // Parse the source URL to extract principalUri and addressbook URI
+        // Format: /addressbooks/{principalId}/{addressbookUri}
+        $sourcePath = $this->subscriptionInfo['source'];
+        $parts = explode('/', trim($sourcePath, '/'));
+
+        if (count($parts) < 3 || $parts[0] !== 'addressbooks') {
+            error_log("Invalid subscription source format: " . $sourcePath);
+            return null;
+        }
+
+        $principalId = $parts[1];
+        $addressbookUri = $parts[2];
+        $principalUri = 'principals/users/' . $principalId;
+
+        // Get the source address book
+        $addressbooks = $this->carddavBackend->getAddressBooksForUser($principalUri);
+        foreach ($addressbooks as $addressbook) {
+            if ($addressbook['uri'] === $addressbookUri) {
+                return $addressbook;
+            }
+        }
+
+        error_log("Source address book not found for subscription: " . $sourcePath);
+        return null;
+    }
+
+    /**
+     * Returns the ACL for child nodes (contacts)
+     *
+     * @return array
+     */
+    function getChildACL() {
+        return $this->getACL();
+    }
+
+    /**
+     * Checks if the subscription has write privileges
+     *
+     * @throws \Sabre\DAV\Exception\Forbidden
+     */
+    protected function checkWriteAccess() {
+        $acl = $this->getACL();
+        $hasWrite = false;
+
+        foreach ($acl as $ace) {
+            // Check for write privileges: write, write-content, bind, unbind, or all
+            if (in_array($ace['privilege'], [
+                '{DAV:}write',
+                '{DAV:}write-content',
+                '{DAV:}bind',
+                '{DAV:}unbind',
+                '{DAV:}all'
+            ])) {
+                $hasWrite = true;
+                break;
+            }
+        }
+
+        if (!$hasWrite) {
+            throw new \Sabre\DAV\Exception\Forbidden('You do not have write access to this subscription');
+        }
+    }
+
+    /**
+     * Checks if the subscription can be deleted
+     *
+     * @throws \Sabre\DAV\Exception\Forbidden
+     */
+    protected function checkDeleteAccess() {
+        $acl = $this->getACL();
+        $hasDelete = false;
+
+        foreach ($acl as $ace) {
+            // Check for delete privileges: unbind or all
+            if (in_array($ace['privilege'], [
+                '{DAV:}unbind',
+                '{DAV:}all'
+            ])) {
+                $hasDelete = true;
+                break;
+            }
+        }
+
+        if (!$hasDelete) {
+            throw new \Sabre\DAV\Exception\Forbidden('You do not have permission to delete this subscription');
+        }
+    }
+
+    /**
+     * Checks if properties can be updated on this subscription
+     *
+     * @throws \Sabre\DAV\Exception\Forbidden
+     */
+    protected function checkWritePropertiesAccess() {
+        $acl = $this->getACL();
+        $hasWriteProperties = false;
+
+        foreach ($acl as $ace) {
+            // Check for write-properties or all privilege
+            if (in_array($ace['privilege'], [
+                '{DAV:}write-properties',
+                '{DAV:}write',
+                '{DAV:}all'
+            ])) {
+                $hasWriteProperties = true;
+                break;
+            }
+        }
+
+        if (!$hasWriteProperties) {
+            throw new \Sabre\DAV\Exception\Forbidden('You do not have permission to modify properties of this subscription');
+        }
+    }
+
+    /**
+     * Returns the list of subscribers (addressbook) of this subscription.
+     *
+     * A subscription itself doesn't have subscribers, but we implement this
+     * method to satisfy the interface expected by plugins.
+     *
+     * @return array Empty array (subscriptions don't have their own subscribers)
+     */
+    function getSubscribedAddressBooks() {
         return [];
+    }
 
+    /**
+     * Returns the number of contacts in the source address book.
+     *
+     * @return int
+     */
+    function getChildCount() {
+        $sourceAddressBookInfo = $this->getSourceAddressBookInfo();
+        if (!$sourceAddressBookInfo) {
+            return 0;
+        }
+
+        return $this->carddavBackend->getCardCount($sourceAddressBookInfo['id']);
+    }
+
+    /**
+     * Returns the sync token for the source address book.
+     *
+     * This is used by clients to detect changes in the address book.
+     *
+     * @return string|null
+     */
+    function getSyncToken() {
+        $sourceAddressBookInfo = $this->getSourceAddressBookInfo();
+        if (!$sourceAddressBookInfo) {
+            return null;
+        }
+
+        if (
+            $this->carddavBackend instanceof \Sabre\CardDAV\Backend\SyncSupport &&
+            isset($sourceAddressBookInfo['{DAV:}sync-token'])
+        ) {
+            return $sourceAddressBookInfo['{DAV:}sync-token'];
+        }
+        if (
+            $this->carddavBackend instanceof \Sabre\CardDAV\Backend\SyncSupport &&
+            isset($sourceAddressBookInfo['{http://sabredav.org/ns}sync-token'])
+        ) {
+            return $sourceAddressBookInfo['{http://sabredav.org/ns}sync-token'];
+        }
+
+        return null;
     }
 
     /**
@@ -123,6 +375,8 @@ class Subscription extends Collection implements ISubscription, IACL {
      * @return void
      */
     function propPatch(PropPatch $propPatch) {
+        // Check write-properties privilege before updating
+        $this->checkWritePropertiesAccess();
 
         return $this->carddavBackend->updateSubscription(
             $this->subscriptionInfo['id'],
@@ -157,6 +411,7 @@ class Subscription extends Collection implements ISubscription, IACL {
                     break;
                 case 'acl':
                     $response['acl'] = $this->getACL();
+                    break;
                 default :
                     if (array_key_exists($prop, $this->subscriptionInfo)) {
                         $response[$prop] = $this->subscriptionInfo[$prop];
@@ -196,15 +451,61 @@ class Subscription extends Collection implements ISubscription, IACL {
      * @return array
      */
     function getACL() {
+        $acl = [];
+        $principal = $this->getOwner();
 
-        return [
-            [
-                'privilege' => '{DAV:}all',
-                'principal' => $this->getOwner(),
-                'protected' => true,
-            ]
+        // Get privilege from subscriptionInfo (default to read-only)
+        $privilege = isset($this->subscriptionInfo['{DAV:}acl'])
+            ? $this->subscriptionInfo['{DAV:}acl']
+            : ['dav:read'];
+
+        // Convert privilege array to detailed ACL
+        // Check what privileges are in the array
+        $hasWrite = in_array('dav:write', $privilege) || in_array('dav:unbind', $privilege);
+        $hasShare = in_array('dav:share', $privilege) || in_array('dav:administration', $privilege);
+
+        // Grant privileges based on the privilege array
+        if ($hasShare) {
+            $acl[] = [
+                'privilege' => '{DAV:}share',
+                'principal' => $principal,
+                'protected' => true
+            ];
+        }
+
+        if ($hasWrite) {
+            $acl[] = [
+                'privilege' => '{DAV:}write-content',
+                'principal' => $principal,
+                'protected' => true
+            ];
+            $acl[] = [
+                'privilege' => '{DAV:}bind',
+                'principal' => $principal,
+                'protected' => true
+            ];
+            $acl[] = [
+                'privilege' => '{DAV:}unbind',
+                'principal' => $principal,
+                'protected' => true
+            ];
+        }
+
+        // Always grant read access
+        $acl[] = [
+            'privilege' => '{DAV:}read',
+            'principal' => $principal,
+            'protected' => true
         ];
 
+        // Always allow the owner to modify subscription properties (displayname, description)
+        $acl[] = [
+            'privilege' => '{DAV:}write-properties',
+            'principal' => $principal,
+            'protected' => true
+        ];
+
+        return $acl;
     }
 
 }

--- a/lib/CardDAV/Subscriptions/Subscription.php
+++ b/lib/CardDAV/Subscriptions/Subscription.php
@@ -106,16 +106,20 @@ class Subscription extends Collection implements ISubscription, IACL {
     /**
      * Returns an array with all the child nodes
      *
+     * @param int $offset
+     * @param int $limit
+     * @param string|null $sort
+     * @param array|null $filters
      * @return \Sabre\DAV\INode[]
      */
-    function getChildren() {
+    function getChildren($offset = 0, $limit = 0, $sort = null, $filters = null) {
         // Get cards from the source address book
         $sourceAddressBookInfo = $this->getSourceAddressBookInfo();
         if (!$sourceAddressBookInfo) {
             return [];
         }
 
-        $objs = $this->carddavBackend->getCards($sourceAddressBookInfo['id']);
+        $objs = $this->carddavBackend->getCards($sourceAddressBookInfo['id'], $offset, $limit, $sort, $filters);
         $children = [];
 
         foreach($objs as $obj) {

--- a/lib/CardDAV/Subscriptions/Subscription.php
+++ b/lib/CardDAV/Subscriptions/Subscription.php
@@ -195,7 +195,7 @@ class Subscription extends Collection implements ISubscription, IACL {
 
         // Parse the source URL to extract principalUri and addressbook URI
         // Format: /addressbooks/{principalId}/{addressbookUri}
-        $sourcePath = $this->subscriptionInfo['source'];
+        $sourcePath = $this->subscriptionInfo[$sourceKey];
         $parts = explode('/', trim($sourcePath, '/'));
 
         if (count($parts) < 3 || $parts[0] !== 'addressbooks') {

--- a/lib/CardDAV/Subscriptions/SubscriptionCard.php
+++ b/lib/CardDAV/Subscriptions/SubscriptionCard.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace ESN\CardDAV\Subscriptions;
+
+/**
+ * Subscription Card
+ *
+ * This node represents a contact card within a subscription.
+ * It wraps a standard Card but enforces ACL checks based on the
+ * subscription's permissions before allowing write operations.
+ */
+class SubscriptionCard extends \Sabre\CardDAV\Card {
+
+    /**
+     * Reference to the subscription node
+     *
+     * @var Subscription
+     */
+    protected $subscription;
+
+    /**
+     * Constructor
+     *
+     * @param \Sabre\CardDAV\Backend\BackendInterface $carddavBackend
+     * @param array $addressBookInfo
+     * @param array $cardData
+     * @param Subscription $subscription
+     */
+    function __construct(\Sabre\CardDAV\Backend\BackendInterface $carddavBackend, array $addressBookInfo, array $cardData, Subscription $subscription) {
+        parent::__construct($carddavBackend, $addressBookInfo, $cardData);
+        $this->subscription = $subscription;
+    }
+
+    /**
+     * Checks if the subscription has write privileges
+     *
+     * @throws \Sabre\DAV\Exception\Forbidden
+     */
+    protected function checkWriteAccess() {
+        $acl = $this->subscription->getACL();
+        $hasWrite = false;
+
+        foreach ($acl as $ace) {
+            // Check for write privileges: write, write-content, bind, unbind, or all
+            if (in_array($ace['privilege'], [
+                '{DAV:}write',
+                '{DAV:}write-content',
+                '{DAV:}bind',
+                '{DAV:}unbind',
+                '{DAV:}all'
+            ])) {
+                $hasWrite = true;
+                break;
+            }
+        }
+
+        if (!$hasWrite) {
+            throw new \Sabre\DAV\Exception\Forbidden('You do not have write access to this subscription');
+        }
+    }
+
+    /**
+     * Updates the VCard-formatted object
+     *
+     * @param string|resource $cardData
+     * @return string|null
+     */
+    function put($cardData) {
+        $this->checkWriteAccess();
+        return parent::put($cardData);
+    }
+
+    /**
+     * Deletes the card
+     *
+     * @return void
+     */
+    function delete() {
+        $this->checkWriteAccess();
+        parent::delete();
+    }
+
+    /**
+     * Returns the ACL for this card based on the subscription's ACL
+     *
+     * @return array
+     */
+    function getACL() {
+        return $this->subscription->getChildACL();
+    }
+}

--- a/tests/CardDAV/Plugin/GetAddressBooksTest.php
+++ b/tests/CardDAV/Plugin/GetAddressBooksTest.php
@@ -195,10 +195,13 @@ class GetAddressBooksTest extends \ESN\CardDAV\PluginTestBase {
 
         $this->assertEquals($addressBooks[0]->{'_links'}->self->href, '/addressbooks/' . $this->userTestId2 . '/user2Subscription1.json');
         $this->assertEquals($addressBooks[0]->{'dav:name'}, 'user2Subscription1');
+
+        // getAddressBookAcl() returns the LAST privilege for a given principal
+        // ACL contains: read + write-properties, so it returns write-properties
         $this->assertEquals(
             $this->getAddressBookAcl($addressBooks[0]),
             array(
-                'principals/users/'. $this->userTestId2 => '{DAV:}all'
+                'principals/users/'. $this->userTestId2 => '{DAV:}write-properties'
             )
         );
 

--- a/tests/CardDAV/Sharing/SharedAddressBookTest.php
+++ b/tests/CardDAV/Sharing/SharedAddressBookTest.php
@@ -2,7 +2,7 @@
 
 namespace ESN\CardDAV\Sharing;
 
-use \Sabre\DAV\Sharing\Plugin as SPlugin;
+use \ESN\DAV\Sharing\Plugin as SPlugin;
 
 require_once ESN_TEST_BASE . '/CardDAV/PluginTestBase.php';
 
@@ -21,7 +21,8 @@ class SharedAddressBookTest extends \ESN\CardDAV\PluginTestBase {
             'id' => '54b64eadf6d7d8e41d263e7e',
             'uri' => 'test',
             'principaluri' => $this->userPrincipal,
-            'share_owner' => 'principals/domains/54b64eadf6d7d8e41d263e9f'
+            'share_owner' => 'principals/domains/54b64eadf6d7d8e41d263e9f',
+            'share_access' => SPlugin::ACCESS_READ
         ];
         $sharedAddressBook = new SharedAddressBook($this->carddavBackend, $addressBook);
 
@@ -39,7 +40,8 @@ class SharedAddressBookTest extends \ESN\CardDAV\PluginTestBase {
             'id' => '54b64eadf6d7d8e41d263e7e',
             'uri' => 'test',
             'principaluri' => $this->userPrincipal,
-            'share_owner' => 'principals/users/54b64eadf6d7d8e41d263e9f'
+            'share_owner' => 'principals/users/54b64eadf6d7d8e41d263e9f',
+            'share_access' => SPlugin::ACCESS_READ
         ];
         $sharedAddressBook = new SharedAddressBook($this->carddavBackend, $addressBook);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscribed address books now operate directly against their source collections and include per-item ACLs.
  * New subscription-backed card type enforces ACL checks on edits and deletions.

* **Improvements**
  * ACLs are built dynamically, persisted on subscriptions, and subscription source is recorded.
  * Stronger access checks when creating subscriptions and when creating/modifying contacts.
  * Sync tokens, counts and property responses now reflect the source collection.
  * New subscriptions default to read-only.

* **Tests**
  * Updated ACL-related tests to expect finer-grained privileges and behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->