### PR TITLE
Fix Dockerfile: failed to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 FROM debian:trixie-slim
-LABEL maintainer Linagora Folks <openpaas@linagora.com>
+LABEL maintainer="Linagora Folks <openpaas@linagora.com>"
 
 ENV PHPVERSION=8.4
 
@@ -52,7 +52,7 @@ RUN apt-get update && \
     pkg-config \
     git && \
   # Compile MongoDB extension
-  pecl install mongodb-2.1.4 && \
+  (pecl install mongodb-2.2.0 || pecl install mongodb) && \
   echo "extension=mongodb.so" >> /etc/php/${PHPVERSION}/fpm/php.ini && \
   echo "extension=mongodb.so" >> /etc/php/${PHPVERSION}/cli/php.ini && \
   # Remove build tools to reduce image size


### PR DESCRIPTION
Fix error when build image

```
 1 warning found (use docker --debug to expand):
 - LegacyKeyValueFormat: "LABEL key=value" should be used instead of legacy "LABEL key value" format (line 18)                                                                     
Dockerfile:101
--------------------
 100 |     # Install dependencies without dev packages (using install to respect composer.lock)
 101 | >>> RUN git config --global --add safe.directory '/var/www/vendor/sabre/vobject' && \
 102 | >>>     composer clearcache && \
 103 | >>>     composer install --no-dev --optimize-autoloader --apcu-autoloader --no-interaction && \
 104 | >>>     # Clean up composer cache and remove git
 105 | >>>     rm -rf /root/.composer/cache && \
 106 | >>>     apt-get purge -y git && \
 107 | >>>     apt-get autoremove -y && \
 108 | >>>     apt-get clean && \
 109 | >>>     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 110 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c git config --global --add safe.directory '/var/www/vendor/sabre/vobject' &&     composer clearcache &&     composer install --no-dev --optimize-autoloader --apcu-autoloader --no-interaction &&     rm -rf /root/.composer/cache &&     apt-get purge -y git &&     apt-get autoremove -y &&     apt-get clean &&     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*" did not complete successfully: exit code: 2

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/w3o1xbm88iswabgwpyze1tiw7
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced MongoDB PHP extension installation with improved fallback handling. The system now attempts installation of a specific version with an automatic fallback mechanism for better reliability.

* **Chores**
  * Minor Docker configuration formatting updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->