### PR TITLE
Fix TypeError when listing calendars with subscription having null/empty source

### DIFF
--- a/lib/JSON/CalDAV/SubscriptionHandler.php
+++ b/lib/JSON/CalDAV/SubscriptionHandler.php
@@ -102,9 +102,19 @@ class SubscriptionHandler {
         if (isset($subprops['{http://calendarserver.org/ns/}source'])) {
             $sourceHref = $subprops['{http://calendarserver.org/ns/}source']->getHref();
 
+            // Skip if source href is null or empty
+            if ($sourceHref === null || $sourceHref === '') {
+                return [404, null];
+            }
+
             // Normalize href: extract path and trim leading slashes
             $path = parse_url($sourceHref, PHP_URL_PATH);
             $sourcePath = ltrim($path ?: $sourceHref, '/');
+
+            // Skip if source path is empty after normalization
+            if ($sourcePath === '') {
+                return [404, null];
+            }
 
             if (!$this->server->tree->nodeExists($sourcePath)) {
                 return [404, null];


### PR DESCRIPTION
## Summary
- Fix crash when listing calendars with `sharedPublicSubscription=true` parameter
- Handles subscriptions that have null or empty source href without crashing
- Added defensive null checks in subscription and calendar path handling

## Root Cause
When a subscription has a null or empty source href, `parse_url()` returns null, and this null value propagates to `getNodeForPath()` which throws:
```
Sabre\Uri\split(): Argument #1 ($path) must be of type string, null given
```

## Changes
- `CalendarHandler::subscriptionToJson()` - skip subscriptions with null/empty source
- `CalendarHandler::calendarToJson()` - skip invites with malformed principal URI
- `SubscriptionHandler::getCalendarObjectsForSubscription()` - return 404 for invalid sources

## Test plan
- [x] Added regression test `testFilteredCalendarListWithEmptySubscriptionSourceDoesNotCrash`
- [x] All existing tests pass (450 tests, 1399 assertions)
- [ ] Manual verification in staging environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of invalid calendar invites by skipping malformed entries and preventing errors during calendar resolution.
  * Enhanced validation for calendar subscriptions to properly return error responses when source references are missing or empty, preventing crashes.

* **Tests**
  * Added regression test to verify graceful handling of subscriptions with broken source data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->