### PR TITLE
ISSUE-268 [Public Agenda] IMipPlugin - publish notificationEmail on organizer chair acceptance transition

### DIFF
--- a/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/lib/CalDAV/Schedule/IMipPlugin.php
@@ -253,7 +253,10 @@ class IMipPlugin extends \Sabre\CalDAV\Schedule\IMipPlugin {
                 }
             }
 
-            return false;
+            // Business rule: for publicly-created events, organizer-chair
+            // moving from NEEDS-ACTION/DECLINED to ACCEPTED should trigger
+            // notification flow even if generic "significant change" is false.
+            return PublicAgendaScheduleUtils::isChairOrganizerAcceptedTransition($formerEvent, $currentEvent);
         } catch (\Exception $e) {
             // If we can't parse, assume no changes
             return false;
@@ -373,7 +376,8 @@ class IMipPlugin extends \Sabre\CalDAV\Schedule\IMipPlugin {
 
             // Create message if instance have been created or modified
             if (!isset($cancelledInstancesId[$recurrenceId]) && (!isset($previousEventVEvents[$recurrenceId]) ||
-                $this->hasInstanceChanged($previousEventVEvents[$recurrenceId], $currentEventVEvents[$recurrenceId]))) {
+                $this->hasInstanceChanged($previousEventVEvents[$recurrenceId], $currentEventVEvents[$recurrenceId]) ||
+                PublicAgendaScheduleUtils::isChairOrganizerAcceptedTransition($formerEvent, $scheduledEvent))) {
 
                 // Check if recipient was attending this occurrence before
                 $isNewOccurrenceException = !isset($previousEventVEvents[$recurrenceId]);

--- a/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/lib/CalDAV/Schedule/IMipPlugin.php
@@ -2,19 +2,16 @@
 
 namespace ESN\CalDAV\Schedule;
 
-use DateTimeZone;
-use \Sabre\DAV;
-use \Sabre\VObject;
-use Sabre\VObject\Component\VCalendar;
+use ESN\Utils\DateTime;
+use ESN\Utils\Utils;
+use Sabre\DAV;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
+use Sabre\VObject;
+use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Component\VEvent;
 use Sabre\VObject\Document;
-use \Sabre\VObject\ITip;
-use \Sabre\VObject\Property;
-use \ESN\Utils\Utils as Utils;
-use ESN\Utils\DateTime;
-use ESN\Utils\DateTimeWithAllDay;
+use Sabre\VObject\ITip;
 use Sabre\VObject\Reader;
 
 #[\AllowDynamicProperties]
@@ -361,6 +358,7 @@ class IMipPlugin extends \Sabre\CalDAV\Schedule\IMipPlugin {
     private function computeModifiedEventMessages(Document $scheduledEvent, Document $formerEvent, string $recipient) {
         $modifiedInstances = [];
         $cancelledEvents = [];
+        $isChairAcceptedTransition = PublicAgendaScheduleUtils::isChairOrganizerAcceptedTransition($formerEvent, $scheduledEvent);
 
         $previousEventVEvents = $this->getSequencePerVEvent($formerEvent);
         $currentEventVEvents = $this->getSequencePerVEvent($scheduledEvent);
@@ -369,15 +367,17 @@ class IMipPlugin extends \Sabre\CalDAV\Schedule\IMipPlugin {
         $clonedScheduledEvent = Utils::safeCloneVObject($scheduledEvent);
 
         foreach ($currentEventVEvents as $recurrenceId => $sequence) {
+            $isAcceptedTransitionForInstance = $isChairAcceptedTransition && $recurrenceId === self::MASTER_EVENT;
             if ($recurrenceId == self::MASTER_EVENT && isset($currentEventVEvents[$recurrenceId]->RRULE)) {
                 // TODO Add RRULE checking to avoid processing non-recurring event
                 list($cancelledEvents, $cancelledInstancesId) = $this->computeMasterEventExDateMessage($previousEventVEvents, $currentEventVEvents, $scheduledEvent);
             }
 
             // Create message if instance have been created or modified
-            if (!isset($cancelledInstancesId[$recurrenceId]) && (!isset($previousEventVEvents[$recurrenceId]) ||
+            $shouldIncludeCurrentInstance = !isset($cancelledInstancesId[$recurrenceId]) && (!isset($previousEventVEvents[$recurrenceId]) ||
                 $this->hasInstanceChanged($previousEventVEvents[$recurrenceId], $currentEventVEvents[$recurrenceId]) ||
-                PublicAgendaScheduleUtils::isChairOrganizerAcceptedTransition($formerEvent, $scheduledEvent))) {
+                $isAcceptedTransitionForInstance);
+            if ($shouldIncludeCurrentInstance) {
 
                 // Check if recipient was attending this occurrence before
                 $isNewOccurrenceException = !isset($previousEventVEvents[$recurrenceId]);

--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -27,6 +27,7 @@ use
  */
 #[\AllowDynamicProperties]
 class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
+    private const MASTER_EVENT = 'master';
 
     private $logger;
     private $principalBackend;
@@ -153,7 +154,7 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
         // Determine the recurrence ID of this message
         $recurrenceId = isset($messageEvent->{'RECURRENCE-ID'})
             ? $messageEvent->{'RECURRENCE-ID'}->getValue()
-            : 'master';
+            : self::MASTER_EVENT;
 
         // Find the corresponding VEVENTs in old and new objects
         $oldVEvent = null;
@@ -162,7 +163,7 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
         foreach ($oldObject->VEVENT as $vevent) {
             $oldRecurId = isset($vevent->{'RECURRENCE-ID'})
                 ? $vevent->{'RECURRENCE-ID'}->getValue()
-                : 'master';
+                : self::MASTER_EVENT;
             if ($oldRecurId === $recurrenceId) {
                 $oldVEvent = $vevent;
                 break;
@@ -172,7 +173,7 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
         foreach ($newObject->VEVENT as $vevent) {
             $newRecurId = isset($vevent->{'RECURRENCE-ID'})
                 ? $vevent->{'RECURRENCE-ID'}->getValue()
-                : 'master';
+                : self::MASTER_EVENT;
             if ($newRecurId === $recurrenceId) {
                 $newVEvent = $vevent;
                 break;
@@ -181,6 +182,12 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
 
         // If this is a new occurrence (wasn't in oldObject), don't skip
         if (!$oldVEvent || !$newVEvent) {
+            return false;
+        }
+
+        // Public Agenda rule: organizer chair transition to ACCEPTED must trigger notification delivery.
+        if ($recurrenceId === self::MASTER_EVENT
+            && PublicAgendaScheduleUtils::isChairOrganizerAcceptedTransition($oldObject, $newObject)) {
             return false;
         }
 

--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -48,53 +48,6 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
 
     }
 
-    private function canonicalizeCalendarAddress($value): string {
-        $value = strtolower(trim((string) $value));
-
-        return strncmp($value, 'mailto:', 7) === 0
-            ? substr($value, 7)
-            : $value;
-    }
-
-    private function isPubliclyCreatedAndNotAcceptedByChairOrganizer(VCalendar $vCal): bool {
-        $vevent = $vCal->VEVENT;
-        if ($vevent === null) {
-            return false;
-        }
-
-        $publiclyCreated = isset($vevent->{'X-PUBLICLY-CREATED'})
-            ? filter_var(trim((string) $vevent->{'X-PUBLICLY-CREATED'}), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)
-            : null;
-
-        if ($publiclyCreated !== true) {
-            return false;
-        }
-
-        $organizer = $vevent->ORGANIZER;
-        if ($organizer === null) {
-            return false;
-        }
-
-        $organizerEmail = $this->canonicalizeCalendarAddress($organizer);
-        foreach ($vevent->select('ATTENDEE') as $attendee) {
-            if ($this->canonicalizeCalendarAddress($attendee) !== $organizerEmail) {
-                continue;
-            }
-
-            $role = strtoupper((string) ($attendee['ROLE'] ?? ''));
-            if ($role !== 'CHAIR') {
-                continue;
-            }
-
-            $partstat = strtoupper((string) ($attendee['PARTSTAT'] ?? ''));
-            $partstat = str_replace('_', '-', $partstat);
-
-            return in_array($partstat, ['NEEDS-ACTION', 'DECLINED'], true);
-        }
-
-        return false;
-    }
-
     /**
      * Used to perform healthchecks on the Message before delivery.
      *
@@ -127,7 +80,7 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
             return;
         }
 
-        if ($this->isPubliclyCreatedAndNotAcceptedByChairOrganizer($vCal)) {
+        if (PublicAgendaScheduleUtils::isPubliclyCreatedAndChairOrganizerNotAccepted($vCal)) {
             return;
         }
 

--- a/lib/CalDAV/Schedule/PublicAgendaScheduleUtils.php
+++ b/lib/CalDAV/Schedule/PublicAgendaScheduleUtils.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace ESN\CalDAV\Schedule;
+
+use Sabre\VObject\Component\VCalendar;
+
+class PublicAgendaScheduleUtils {
+    private static string $PUBLICLY_CREATED_HEADER = 'X-PUBLICLY-CREATED';
+    private static array $NOT_ACCEPTED_PARTSTATS = ['NEEDS-ACTION', 'DECLINED'];
+    private static array $ACCEPTED_PARTSTATS = ['ACCEPTED', 'TENTATIVE'];
+
+    public static function isPubliclyCreatedAndChairOrganizerNotAccepted(VCalendar $vCal): bool {
+        if (self::parsePubliclyCreatedFlag($vCal) !== true) {
+            return false;
+        }
+
+        $partstat = self::getChairOrganizerPartstat($vCal);
+        return in_array($partstat, self::$NOT_ACCEPTED_PARTSTATS, true);
+    }
+
+    public static function isChairOrganizerAcceptedTransition(VCalendar $formerEvent, VCalendar $currentEvent): bool {
+        if (self::parsePubliclyCreatedFlag($currentEvent) !== true) {
+            return false;
+        }
+
+        $oldPartstat = self::getChairOrganizerPartstat($formerEvent);
+        $newPartstat = self::getChairOrganizerPartstat($currentEvent);
+
+        return in_array($oldPartstat, self::$NOT_ACCEPTED_PARTSTATS, true)
+            && in_array($newPartstat, self::$ACCEPTED_PARTSTATS, true);
+    }
+
+    private static function parsePubliclyCreatedFlag(VCalendar $vCal): ?bool {
+        $vevent = $vCal->VEVENT;
+        if ($vevent === null || !isset($vevent->{self::$PUBLICLY_CREATED_HEADER})) {
+            return null;
+        }
+
+        return filter_var(trim((string) $vevent->{self::$PUBLICLY_CREATED_HEADER}), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+    }
+
+    private static function getChairOrganizerPartstat(VCalendar $vCal): ?string {
+        $vevent = $vCal->VEVENT;
+        if ($vevent === null || $vevent->ORGANIZER === null) {
+            return null;
+        }
+
+        $organizerEmail = self::canonicalizeCalendarAddress($vevent->ORGANIZER);
+        foreach ($vevent->select('ATTENDEE') as $attendee) {
+            if (self::canonicalizeCalendarAddress($attendee) !== $organizerEmail) {
+                continue;
+            }
+
+            $role = strtoupper((string) ($attendee['ROLE'] ?? ''));
+            if ($role !== 'CHAIR') {
+                continue;
+            }
+
+            $partstat = strtoupper((string) ($attendee['PARTSTAT'] ?? ''));
+            $partstat = str_replace('_', '-', $partstat);
+
+            return $partstat;
+        }
+
+        return null;
+    }
+
+    private static function canonicalizeCalendarAddress($value): string {
+        $value = strtolower(trim((string) $value));
+
+        return strncmp($value, 'mailto:', 7) === 0
+            ? substr($value, 7)
+            : $value;
+    }
+}

--- a/lib/CalDAV/Schedule/PublicAgendaScheduleUtils.php
+++ b/lib/CalDAV/Schedule/PublicAgendaScheduleUtils.php
@@ -56,7 +56,7 @@ class PublicAgendaScheduleUtils {
                 continue;
             }
 
-            $partstat = strtoupper((string) ($attendee['PARTSTAT'] ?? ''));
+            $partstat = strtoupper((string) ($attendee['PARTSTAT'] ?? 'NEEDS-ACTION'));
             $partstat = str_replace('_', '-', $partstat);
 
             return $partstat;

--- a/run_test.sh
+++ b/run_test.sh
@@ -61,7 +61,7 @@ if [ "$SKIP_JAVA" = true ]; then
 fi
 
 (
-  git clone https://github.com/linagora/twake-calendar-integration-tests.git it-tests
+  git clone -b email-publicly-created https://github.com/linagora/twake-calendar-integration-tests.git it-tests
   cd it-tests
   bash pre-build.sh esn_sabre_test
   mvn clean install -Dapi.version=1.43 -Dtest=com.linagora.dav.sabrev4_7.**

--- a/run_test.sh
+++ b/run_test.sh
@@ -61,7 +61,7 @@ if [ "$SKIP_JAVA" = true ]; then
 fi
 
 (
-  git clone -b email-publicly-created https://github.com/linagora/twake-calendar-integration-tests.git it-tests
+  git clone https://github.com/linagora/twake-calendar-integration-tests.git it-tests
   cd it-tests
   bash pre-build.sh esn_sabre_test
   mvn clean install -Dapi.version=1.43 -Dtest=com.linagora.dav.sabrev4_7.**

--- a/tests/CalDAV/Schedule/SchedulePluginTest.php
+++ b/tests/CalDAV/Schedule/SchedulePluginTest.php
@@ -9,17 +9,12 @@ use Sabre\VObject\Reader;
 #[\AllowDynamicProperties]
 class SchedulePluginTest extends \PHPUnit\Framework\TestCase {
     private $plugin;
-    private $publiclyCreatedCheckMethod;
 
     function setUp(): void {
         $server = new Server();
 
         $this->plugin = new Plugin();
         $this->plugin->initialize($server);
-
-        $reflection = new \ReflectionClass($this->plugin);
-        $this->publiclyCreatedCheckMethod = $reflection->getMethod('isPubliclyCreatedAndNotAcceptedByChairOrganizer');
-        $this->publiclyCreatedCheckMethod->setAccessible(true);
     }
 
     function testDeliverShouldSetSequenceTo0WhenNotPresent() {
@@ -49,7 +44,7 @@ class SchedulePluginTest extends \PHPUnit\Framework\TestCase {
     function testShouldDetectPubliclyCreatedWhenChairOrganizerNeedsAction() {
         $vcalendar = Reader::read($this->newCalendarWithOrganizerChairPartstat('NEEDS-ACTION', true));
 
-        $shouldSkip = $this->publiclyCreatedCheckMethod->invoke($this->plugin, $vcalendar);
+        $shouldSkip = PublicAgendaScheduleUtils::isPubliclyCreatedAndChairOrganizerNotAccepted($vcalendar);
 
         $this->assertTrue($shouldSkip);
     }
@@ -57,7 +52,7 @@ class SchedulePluginTest extends \PHPUnit\Framework\TestCase {
     function testShouldNotSkipWhenChairOrganizerAcceptedEvenIfPubliclyCreated() {
         $vcalendar = Reader::read($this->newCalendarWithOrganizerChairPartstat('ACCEPTED', true));
 
-        $shouldSkip = $this->publiclyCreatedCheckMethod->invoke($this->plugin, $vcalendar);
+        $shouldSkip = PublicAgendaScheduleUtils::isPubliclyCreatedAndChairOrganizerNotAccepted($vcalendar);
 
         $this->assertFalse($shouldSkip);
     }


### PR DESCRIPTION
ref https://github.com/linagora/twake-calendar-side-service/issues/612

Add Public Agenda policy logic for:

- Ensure `IMipPlugin.php` generates and publishes attendee notification messages for the accepted transition case.
- Keep non-public-agenda behavior unchanged.

Similar to approach already implemented for `calendar:event:created` in PR
- https://github.com/linagora/esn-sabre/pull/270


Downstream test:
- https://github.com/linagora/twake-calendar-integration-tests/pull/167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved notification handling for publicly created calendar events so chair/organizer ACCEPTED transitions are observed for master and recurrence instances.

* **Bug Fixes**
  * Fixed cases where chair/organizer acceptance did not trigger modification messages or caused unchanged occurrences to be skipped.

* **Tests**
  * Added and updated tests covering publicly created events and chair acceptance transition scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->