### PR TITLE
fix(itip): allow REPLY without ORGANIZER when sender is attendee

### DIFF
--- a/lib/CalDAV/Schedule/ITipPlugin.php
+++ b/lib/CalDAV/Schedule/ITipPlugin.php
@@ -64,7 +64,7 @@ class ITipPlugin extends \Sabre\DAV\ServerPlugin {
         //
         // Some use cases, like a user forwarding an invite email to another user, brings a recipient
         // that is not, at all, in the event. We ignore it
-        if (!$this->assertRecipientIsConcernedByEvent($message->message->vevent, $message->recipient)) {
+        if (!$this->assertRecipientIsConcernedByEvent($message)) {
             $this->server->getLogger()->error("Recipient ". $message->recipient ." is not organizer, not attendee of event ". (string)$message->message->VEVENT->UID .": skipping");
             return $this->send(400, null);
         }
@@ -103,11 +103,17 @@ class ITipPlugin extends \Sabre\DAV\ServerPlugin {
         };
     }
 
-    private function assertRecipientIsConcernedByEvent($vevent, $recipient)
+    private function assertRecipientIsConcernedByEvent(Message $message)
     {
+        $vevent = $message->message->VEVENT;
+        $recipient = $message->recipient;
+
         $isConcerned = false;
+        $hasOrganizer = false;
+        $senderIsAttendee = false;
         try {
             $organizer = (string)$vevent->ORGANIZER;
+            $hasOrganizer = trim((string)$organizer) !== '';
             if (strtolower($organizer) === strtolower($recipient)) {
                 $isConcerned = true;
             }
@@ -118,9 +124,17 @@ class ITipPlugin extends \Sabre\DAV\ServerPlugin {
             foreach ($vevent->ATTENDEE as $attendee) {
                 if (strtolower((string)$attendee) === strtolower($recipient)) {
                     $isConcerned = true;
-                    break;
+                } else if (strtolower((string)$attendee) === strtolower((string)$message->sender)) {
+                    $senderIsAttendee = true;
                 }
             }
+        }
+
+        if (!$isConcerned
+            && strtoupper((string)$message->method) === 'REPLY'
+            && !$hasOrganizer
+            && $senderIsAttendee) {
+            $isConcerned = true;
         }
 
         return $isConcerned;

--- a/run_test.sh
+++ b/run_test.sh
@@ -61,7 +61,7 @@ if [ "$SKIP_JAVA" = true ]; then
 fi
 
 (
-  git clone https://github.com/linagora/twake-calendar-integration-tests.git it-tests
+  git clone -b ISSUE-629 https://github.com/linagora/twake-calendar-integration-tests.git it-tests
   cd it-tests
   bash pre-build.sh esn_sabre_test
   mvn clean install -Dapi.version=1.43 -Dtest=com.linagora.dav.sabrev4_7.**

--- a/run_test.sh
+++ b/run_test.sh
@@ -61,7 +61,7 @@ if [ "$SKIP_JAVA" = true ]; then
 fi
 
 (
-  git clone -b ISSUE-629 https://github.com/linagora/twake-calendar-integration-tests.git it-tests
+  git clone https://github.com/linagora/twake-calendar-integration-tests.git it-tests
   cd it-tests
   bash pre-build.sh esn_sabre_test
   mvn clean install -Dapi.version=1.43 -Dtest=com.linagora.dav.sabrev4_7.**

--- a/tests/CalDAV/Schedule/ITipPluginTest.php
+++ b/tests/CalDAV/Schedule/ITipPluginTest.php
@@ -208,7 +208,7 @@ END:VCALENDAR';
     function testITipReplyWithoutOrganizerShouldReturn400WhenSenderIsNotAttendee()
     {
         $this->iTipRequestData['method'] = 'REPLY';
-        $this->iTipRequestData['recipient'] = 'b@linagora.com';
+        $this->iTipRequestData['recipient'] = 'c@linagora.com';
         $this->iTipRequestData['sender'] = 'x@linagora.com';
         $this->iTipRequestData['ical'] = 'BEGIN:VCALENDAR
 VERSION:2.0

--- a/tests/CalDAV/Schedule/ITipPluginTest.php
+++ b/tests/CalDAV/Schedule/ITipPluginTest.php
@@ -177,6 +177,62 @@ END:VCALENDAR'
         $this->assertEquals(204, $response->getStatus());
     }
 
+    function testITipReplyWithoutOrganizerShouldReturn204WhenSenderIsAttendee()
+    {
+        $this->iTipRequestData['method'] = 'REPLY';
+        $this->iTipRequestData['recipient'] = 'b@linagora.com';
+        $this->iTipRequestData['sender'] = 'a@linagora.com';
+        $this->iTipRequestData['ical'] = 'BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+CREATED:20120313T142342Z
+UID:event1
+DTEND;TZID=Europe/Berlin:20120227T000000
+TRANSP:OPAQUE
+SUMMARY:Monday 0h
+DTSTART;TZID=Europe/Berlin:20120227T000000
+DTSTAMP:20120313T142416Z
+SEQUENCE:4
+ATTENDEE:mailto:b@linagora.com
+ATTENDEE:mailto:a@linagora.com
+END:VEVENT
+END:VCALENDAR';
+
+        $request = $this->makeRequest($this->iTipRequestData);
+        $this->iTipPlugin->iTip($request);
+
+        $response = $this->server->httpResponse;
+        $this->assertEquals(204, $response->getStatus());
+    }
+
+    function testITipReplyWithoutOrganizerShouldReturn400WhenSenderIsNotAttendee()
+    {
+        $this->iTipRequestData['method'] = 'REPLY';
+        $this->iTipRequestData['recipient'] = 'b@linagora.com';
+        $this->iTipRequestData['sender'] = 'x@linagora.com';
+        $this->iTipRequestData['ical'] = 'BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+CREATED:20120313T142342Z
+UID:event1
+DTEND;TZID=Europe/Berlin:20120227T000000
+TRANSP:OPAQUE
+SUMMARY:Monday 0h
+DTSTART;TZID=Europe/Berlin:20120227T000000
+DTSTAMP:20120313T142416Z
+SEQUENCE:4
+ATTENDEE:mailto:b@linagora.com
+ATTENDEE:mailto:a@linagora.com
+END:VEVENT
+END:VCALENDAR';
+
+        $request = $this->makeRequest($this->iTipRequestData);
+        $this->iTipPlugin->iTip($request);
+
+        $response = $this->server->httpResponse;
+        $this->assertEquals(400, $response->getStatus());
+    }
+
 }
 
 #[\AllowDynamicProperties]


### PR DESCRIPTION
## Problem
Some external clients send malformed iTIP REPLY messages without ORGANIZER.
In this case, esn-sabre returned 400 even when the reply sender was a valid attendee of the event.

## Root Cause
`ITipPlugin::assertRecipientIsConcernedByEvent` considered recipient valid only if:

- recipient matches ORGANIZER, or
- recipient is listed in ATTENDEE.
For REPLY without ORGANIZER, recipient (organizer side) may not be found by these checks, so the request was rejected.

## Fix
- Adjusted recipient-concern validation for REPLY
- Keep existing organizer/attendee checks.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * iTip REPLY handling: when an event has no organizer, sender membership is now considered—senders listed as attendees yield HTTP 204, others yield HTTP 400.
* **Tests**
  * Added tests covering REPLY behavior with and without organizer for sender-as-attendee vs non-attendee scenarios.
* **Chores**
  * Integration test runner now checks out a specific test branch to ensure consistent test sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->