### PR TITLE
[FIX] Off by one sync token

### DIFF
--- a/lib/Publisher/CalDAV/EventRealTimePlugin.php
+++ b/lib/Publisher/CalDAV/EventRealTimePlugin.php
@@ -460,7 +460,6 @@ class EventRealTimePlugin extends \ESN\Publisher\RealTimePlugin {
             }
         }
 
-        $this->publishMessages();
         return true;
     }
 


### PR DESCRIPTION
RabbitMQ messages now guaranteed to fire after syncToken persisted

  1. The schedule() method in EventRealTimePlugin called publishMessages() at the end, which could fire during beforeWriteContent — before $node->put() incremented the syncToken in MongoDB.
  2. This created a race condition: a client receiving the RabbitMQ notification could immediately REPORT with syncToken N, get an empty response (syncToken still N in DB), and permanently miss the change.
  3. The fix removes the publishMessages() call from schedule(), letting queued messages accumulate until after() fires on afterWriteContent/afterCreateFile/afterUnbind — all of which run after the backend write and syncToken increment.
  4. The ITIP HTTP method path is unaffected: itip() already calls publishMessages() after schedule() returns (line 469).
  5. The COUNTER branch is also unaffected: schedule() returns early before any messages are queued for that method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted event message publishing timing in real-time plugin to improve internal message handling flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->