### PR TITLE
CI - split test stages in Jenkinsfile and extend run_test.sh flags

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,9 +11,19 @@ pipeline {
     }
 
     stages {
+      stage('Build Test Images') {
+          steps {
+              sh 'bash run_test.sh --skip-java --skip-php'
+          }
+      }
       stage('Compile and Test') {
           steps {
-              sh 'bash run_test.sh'
+              sh 'bash run_test.sh --skip-java --skip-build'
+          }
+       }
+       stage('Run Integration Test') {
+          steps {
+              sh 'bash run_test.sh --skip-php --skip-build'
           }
       }
       stage('Deliver Docker images') {

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,14 +1,20 @@
 #!/bin/bash
 set -euo pipefail
 
-# Usage: ./run_test.sh [--filter=TestClassName] [--skip-java]
+# Usage: ./run_test.sh [--filter=TestClassName] [--skip-java] [--skip-php] [--skip-build]
 # Examples:
-#   ./run_test.sh --filter=IMipPluginTest
-#   ./run_test.sh --skip-java
-#   ./run_test.sh --filter=IMipPluginTest --skip-java
+#   ./run_test.sh                                          # Run everything
+#   ./run_test.sh --skip-build                            # Skip docker build, run all tests
+#   ./run_test.sh --skip-java                             # Run PHP tests only
+#   ./run_test.sh --skip-php                              # Run Java integration tests only
+#   ./run_test.sh --filter=IMipPluginTest                 # Run PHP tests with filter
+#   ./run_test.sh --filter=IMipPluginTest --skip-build    # Run PHP tests with filter, skip build
+#   ./run_test.sh --skip-java --skip-php                  # Build Docker images only
 
 FILTER=""
 SKIP_JAVA=false
+SKIP_PHP=false
+SKIP_BUILD=false
 
 for arg in "$@"; do
   case $arg in
@@ -20,9 +26,17 @@ for arg in "$@"; do
       SKIP_JAVA=true
       shift
       ;;
+    --skip-php)
+      SKIP_PHP=true
+      shift
+      ;;
+    --skip-build)
+      SKIP_BUILD=true
+      shift
+      ;;
     *)
       echo "Unknown option: $arg"
-      echo "Usage: $0 [--filter=TestClassName] [--skip-java]"
+      echo "Usage: $0 [--filter=TestClassName] [--skip-java] [--skip-php] [--skip-build]"
       exit 1
       ;;
   esac
@@ -38,23 +52,29 @@ trap cleanup EXIT  # finally: sera exécuté *quoi qu'il arrive*
 # Pre Cleanup
 docker compose -f docker-compose.test.yaml down --volumes --remove-orphans || true
 
-docker build -t esn-sabre-ldap-test -f Dockerfile.ldap .
-docker build -t esn_sabre_test -f Dockerfile.test .
-
-# Build PHP test command
-if [ -n "$FILTER" ]; then
-  echo "Running PHP tests with filter: $FILTER"
-  docker compose -f docker-compose.test.yaml run --rm esn_test bash -c "sleep 5 && make lint && vendor/bin/phpunit -c tests/phpunit.xml --filter=$FILTER tests"
-else
-  echo "Running all PHP tests"
-  docker compose -f docker-compose.test.yaml run --rm esn_test bash -c "sleep 5 && make lint && make test"
-fi
-exit_code_1=$?
-
-if [ $exit_code_1 -ne 0 ]; then
-  exit 1
+# Build Docker images
+if [ "$SKIP_BUILD" = false ]; then
+  docker build -t esn-sabre-ldap-test -f Dockerfile.ldap .
+  docker build -t esn_sabre_test -f Dockerfile.test .
 fi
 
+# PHP tests
+if [ "$SKIP_PHP" = false ]; then
+  if [ -n "$FILTER" ]; then
+    echo "Running PHP tests with filter: $FILTER"
+    docker compose -f docker-compose.test.yaml run --rm esn_test bash -c "sleep 5 && make lint && vendor/bin/phpunit -c tests/phpunit.xml --filter=$FILTER tests"
+  else
+    echo "Running all PHP tests"
+    docker compose -f docker-compose.test.yaml run --rm esn_test bash -c "sleep 5 && make lint && make test"
+  fi
+  exit_code_1=$?
+
+  if [ $exit_code_1 -ne 0 ]; then
+    exit 1
+  fi
+fi
+
+# Java integration tests
 if [ "$SKIP_JAVA" = true ]; then
   echo "Skipping Java integration tests"
   exit 0


### PR DESCRIPTION
- Add 'Run Integration Test' stage to Jenkinsfile, separate from 'Compile and Test'
- Add 'Build Test Images' stage to avoid redundant docker builds across stages
- Add --skip-php flag to run Java integration tests only
- Add --skip-build flag to reuse previously built Docker images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized CI/CD pipeline test execution with separate stages for Docker image building and integration testing
  * Added new configuration options to selectively skip specific test components (build, PHP testing) for more granular pipeline control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->