### PR TITLE
ISSUE-1208 fix(caldav): tighten iTIP sender/recipient authorization

### DIFF
--- a/lib/CalDAV/Schedule/ITipPlugin.php
+++ b/lib/CalDAV/Schedule/ITipPlugin.php
@@ -2,10 +2,13 @@
 
 namespace ESN\CalDAV\Schedule;
 
+use ESN\CalDAV\SharedCalendar;
 use \Sabre\DAV\Exception;
 use \Sabre\VObject;
 use \Sabre\VObject\ITip\Message;
 use \Sabre\DAV;
+use ESN\Utils\Utils;
+use ESN\DAV\Sharing\Plugin as SharingPlugin;
 
 
 class ITipPlugin extends \Sabre\DAV\ServerPlugin {
@@ -69,6 +72,14 @@ class ITipPlugin extends \Sabre\DAV\ServerPlugin {
         $message->message = VObject\Reader::read($payload->ical);
         $message->sender = $this->resolveSenderFromItipMessage($message, $issetdef('replyTo', $payload->sender));
         $message->recipient = 'mailto:' . $payload->recipient;
+
+        if (strtoupper((string)$message->method) === 'COUNTER') {
+            if (!$this->authenticatedCanActAsSender($message, true)) {
+                return $this->send(403, null);
+            }
+        } elseif (!$this->recipientMatchesCurrentUser($message)) {
+            return $this->send(403, null);
+        }
 
         // we need to check that the current user ($message->recipient) is related to the event,
         // because he's either organizer, or attendee, or both.
@@ -147,7 +158,111 @@ class ITipPlugin extends \Sabre\DAV\ServerPlugin {
         return strtolower($calendarAddress) === strtolower($emailOrAddress);
     }
 
-    private function assertRecipientIsConcernedByEvent(Message $message)
+    private function authenticatedCanActAsSender(Message $message, bool $allowDelegation): bool
+    {
+        $authPlugin = $this->server->getPlugin('auth');
+        $aclPlugin = $this->server->getPlugin('acl');
+        if (!$authPlugin || !$aclPlugin) {
+            return false;
+        }
+
+        $currentPrincipal = $this->normalizePrincipalUri($authPlugin->getCurrentPrincipal());
+        if (!$currentPrincipal) {
+            return false;
+        }
+
+        $senderPrincipal = $this->normalizePrincipalUri(Utils::getPrincipalByUri($message->sender, $this->server));
+        if (!$senderPrincipal) {
+            return false;
+        }
+
+        if ($this->principalsMatch($aclPlugin, $senderPrincipal, $currentPrincipal)) {
+            return true;
+        }
+
+        return $allowDelegation && $this->hasDelegatedWriteAccess($aclPlugin, $senderPrincipal, $currentPrincipal);
+    }
+
+    private function hasDelegatedWriteAccess($aclPlugin, string $principalUri, string $currentPrincipal): bool
+    {
+        if ($this->principalsMatch($aclPlugin, $principalUri . '/calendar-proxy-write', $currentPrincipal)) {
+            return true;
+        }
+
+        return $this->hasWritableSharedCalendarFromSender($principalUri, $currentPrincipal);
+    }
+
+    private function hasWritableSharedCalendarFromSender(string $senderPrincipal, string $currentPrincipal): bool
+    {
+        $homePath = 'calendars/' . basename($currentPrincipal);
+
+        try {
+            $homeNode = $this->server->tree->getNodeForPath($homePath);
+        } catch (\Throwable $e) {
+            return false;
+        }
+
+        if (!method_exists($homeNode, 'getChildren')) {
+            return false;
+        }
+
+        foreach ($homeNode->getChildren() as $child) {
+            if (!($child instanceof SharedCalendar) || !$child->isSharedInstance()) {
+                continue;
+            }
+
+            $shareOwner = $this->normalizePrincipalUri($child->getOwner());
+            if (!$shareOwner || !$this->principalsMatch($this->server->getPlugin('acl'), $shareOwner, $senderPrincipal)) {
+                continue;
+            }
+
+            $shareAccess = (int) $child->getShareAccess();
+            if ($shareAccess === SharingPlugin::ACCESS_READWRITE || $shareAccess === SharingPlugin::ACCESS_ADMINISTRATION) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function recipientMatchesCurrentUser(Message $message): bool
+    {
+        $authPlugin = $this->server->getPlugin('auth');
+        $aclPlugin = $this->server->getPlugin('acl');
+        if (!$authPlugin || !$aclPlugin) {
+            return false;
+        }
+
+        $currentPrincipal = $this->normalizePrincipalUri($authPlugin->getCurrentPrincipal());
+        if (!$currentPrincipal) {
+            return false;
+        }
+
+        $recipientPrincipal = $this->normalizePrincipalUri(Utils::getPrincipalByUri($message->recipient, $this->server));
+        return $recipientPrincipal && $this->principalsMatch($aclPlugin, $recipientPrincipal, $currentPrincipal);
+    }
+
+    private function principalsMatch($aclPlugin, string $principal, string $currentPrincipal): bool
+    {
+        $a = ltrim($principal, '/');
+        $b = ltrim($currentPrincipal, '/');
+
+        return $aclPlugin->principalMatchesPrincipal($a, $b)
+            || $aclPlugin->principalMatchesPrincipal("/$a", $b)
+            || $aclPlugin->principalMatchesPrincipal($a, "/$b")
+            || $aclPlugin->principalMatchesPrincipal("/$a", "/$b");
+    }
+
+    private function normalizePrincipalUri(?string $principal): ?string
+    {
+        if (!$principal) {
+            return null;
+        }
+
+        return ltrim($principal, '/');
+    }
+
+    private function assertRecipientIsConcernedByEvent(Message $message): bool
     {
         $vevent = $message->message->VEVENT;
         $recipient = $message->recipient;

--- a/run_test.sh
+++ b/run_test.sh
@@ -81,7 +81,7 @@ if [ "$SKIP_JAVA" = true ]; then
 fi
 
 (
-  git clone -b test/itip-authz https://github.com/vttranlina/twake-calendar-integration-tests.git it-tests
+  git clone https://github.com/linagora/twake-calendar-integration-tests.git it-tests
   cd it-tests
   bash pre-build.sh esn_sabre_test
   mvn clean install -Dapi.version=1.43 -Dtest=com.linagora.dav.sabrev4_7.**

--- a/run_test.sh
+++ b/run_test.sh
@@ -81,7 +81,7 @@ if [ "$SKIP_JAVA" = true ]; then
 fi
 
 (
-  git clone https://github.com/linagora/twake-calendar-integration-tests.git it-tests
+  git clone -b test/itip-authz https://github.com/vttranlina/twake-calendar-integration-tests.git it-tests
   cd it-tests
   bash pre-build.sh esn_sabre_test
   mvn clean install -Dapi.version=1.43 -Dtest=com.linagora.dav.sabrev4_7.**

--- a/tests/CalDAV/Schedule/ITipPluginTest.php
+++ b/tests/CalDAV/Schedule/ITipPluginTest.php
@@ -43,9 +43,23 @@ END:VCALENDAR'
     {
         $this->iTipPlugin = new ITipPlugin();
         $this->calDavPlugin = new CalDavPluginMock();
+        $this->authPlugin = new AuthPluginMock('principals/users/b');
+        $this->aclPlugin = new AclPluginMock([
+            'mailto:a@linagora.com' => 'principals/users/a',
+            'mailto:b@linagora.com' => 'principals/users/b',
+            'mailto:c@linagora.com' => 'principals/users/c',
+            'mailto:x@linagora.com' => 'principals/users/x',
+        ]);
         $this->server = new \Sabre\DAV\Server([]);
+        $this->server->addPlugin($this->authPlugin);
+        $this->server->addPlugin($this->aclPlugin);
         $this->server->addPlugin($this->iTipPlugin);
         $this->server->addPlugin($this->calDavPlugin);
+    }
+
+    private function setAuthenticatedPrincipal(string $principal): void
+    {
+        $this->authPlugin->setCurrentPrincipal($principal);
     }
 
     function makeRequest($body)
@@ -114,6 +128,7 @@ END:VCALENDAR'
     function testITipShouldReturn400IfRecipientIsNotConcernedByEvent()
     {
         $this->iTipRequestData['recipient'] = 'c@linagora.com';
+        $this->setAuthenticatedPrincipal('principals/users/c');
         $request = $this->makeRequest($this->iTipRequestData);
 
         $this->iTipPlugin->iTip($request);
@@ -166,6 +181,7 @@ END:VCALENDAR'
             $scheduleCalled = true;
         });
         $this->iTipRequestData['method'] = 'COUNTER';
+        $this->iTipRequestData['sender'] = 'b@linagora.com';
         $request = $this->makeRequest($this->iTipRequestData);
 
         $this->iTipPlugin->iTip($request);
@@ -210,6 +226,7 @@ END:VCALENDAR';
         $this->iTipRequestData['method'] = 'REPLY';
         $this->iTipRequestData['recipient'] = 'c@linagora.com';
         $this->iTipRequestData['sender'] = 'x@linagora.com';
+        $this->setAuthenticatedPrincipal('principals/users/c');
         $this->iTipRequestData['ical'] = 'BEGIN:VCALENDAR
 VERSION:2.0
 BEGIN:VEVENT
@@ -233,6 +250,42 @@ END:VCALENDAR';
         $this->assertEquals(400, $response->getStatus());
     }
 
+    function testITipShouldReturn403IfMethodIsNotCounterAndAuthenticatedIsNotRecipient()
+    {
+        $this->setAuthenticatedPrincipal('principals/users/a');
+        $request = $this->makeRequest($this->iTipRequestData);
+
+        $this->iTipPlugin->iTip($request);
+
+        $response = $this->server->httpResponse;
+        $this->assertEquals(403, $response->getStatus());
+    }
+
+    function testITipCounterShouldReturn403WhenAuthenticatedCannotActAsSender()
+    {
+        $this->iTipRequestData['method'] = 'COUNTER';
+        $request = $this->makeRequest($this->iTipRequestData);
+
+        $this->iTipPlugin->iTip($request);
+
+        $response = $this->server->httpResponse;
+        $this->assertEquals(403, $response->getStatus());
+    }
+
+    function testITipCounterShouldReturn204WhenAuthenticatedHasWriteAccessToSender()
+    {
+        $this->iTipRequestData['method'] = 'COUNTER';
+        $this->aclPlugin->setMemberships([
+            'principals/users/a/calendar-proxy-write' => ['principals/users/b'],
+        ]);
+        $request = $this->makeRequest($this->iTipRequestData);
+
+        $this->iTipPlugin->iTip($request);
+
+        $response = $this->server->httpResponse;
+        $this->assertEquals(204, $response->getStatus());
+    }
+
 }
 
 #[\AllowDynamicProperties]
@@ -253,4 +306,91 @@ class CalDavPluginMock extends ServerPlugin
         return;
     }
 
+}
+
+#[\AllowDynamicProperties]
+class AuthPluginMock extends ServerPlugin
+{
+    private $currentPrincipal;
+
+    function __construct(string $currentPrincipal)
+    {
+        $this->currentPrincipal = $currentPrincipal;
+    }
+
+    function getPluginName()
+    {
+        return 'auth';
+    }
+
+    function initialize(\Sabre\DAV\Server $server)
+    {
+        $this->server = $server;
+    }
+
+    function setCurrentPrincipal(string $principal): void
+    {
+        $this->currentPrincipal = $principal;
+    }
+
+    function getCurrentPrincipal(): string
+    {
+        return $this->currentPrincipal;
+    }
+}
+
+#[\AllowDynamicProperties]
+class AclPluginMock extends ServerPlugin
+{
+    private $principalMap;
+    private $writablePaths = [];
+    private $memberships = [];
+
+    function __construct(array $principalMap)
+    {
+        $this->principalMap = $principalMap;
+    }
+
+    function getPluginName()
+    {
+        return 'acl';
+    }
+
+    function initialize(\Sabre\DAV\Server $server)
+    {
+        $this->server = $server;
+    }
+
+    function setWritablePaths(array $paths): void
+    {
+        $this->writablePaths = $paths;
+    }
+
+    function setMemberships(array $memberships): void
+    {
+        $this->memberships = $memberships;
+    }
+
+    function getPrincipalByUri($uri)
+    {
+        if (!is_string($uri)) {
+            return null;
+        }
+
+        $normalized = strtolower($uri);
+        return $this->principalMap[$normalized] ?? null;
+    }
+
+    function principalMatchesPrincipal($candidate, $current): bool
+    {
+        $c = strtolower(trim((string)$candidate, '/'));
+        $p = strtolower(trim((string)$current, '/'));
+        if ($c === $p) return true;
+        return in_array($p, $this->memberships[$c] ?? [], true);
+    }
+
+    function checkPrivileges($path, $privilege, $recursion = null, $throwExceptions = null): bool
+    {
+        return in_array(ltrim((string)$path, '/'), $this->writablePaths, true);
+    }
 }


### PR DESCRIPTION
Add auth checks before processing iTIP scheduling messages.
- Require COUNTER requests to be sent by the authenticated principal or a valid delegate with write access.
- Require other methods to target the authenticated recipient, blocking spoofed scheduling actions.

relate https://github.com/linagora/james-project-private/issues/1208