### PR TITLE
ISSUE-347 fix(caldav subscriptions): reject writes without source calendar access

### DIFF
--- a/lib/CalDAV/Subscriptions/SubscriptionObject.php
+++ b/lib/CalDAV/Subscriptions/SubscriptionObject.php
@@ -32,6 +32,20 @@ class SubscriptionObject extends CalendarObject {
         $this->subscriptionOwner = $subscriptionOwner;
     }
 
+    function put($calendarData) {
+        $this->checkWriteAccess();
+
+        return parent::put($calendarData);
+    }
+
+    /**
+     * Deletes the calendar object from the subscription view.
+     */
+    function delete() {
+        $this->checkWriteAccess();
+        parent::delete();
+    }
+
     /**
      * Returns a list of ACE's for this node.
      *
@@ -74,5 +88,18 @@ class SubscriptionObject extends CalendarObject {
         // Check if the source calendar has public write right
         $publicRight = $this->caldavBackend->getCalendarPublicRight($this->calendarInfo['id']);
         return $publicRight === '{DAV:}write';
+    }
+
+    /**
+     * Ensures the subscription owner can modify objects in the source calendar.
+     *
+     * @throws \Sabre\DAV\Exception\Forbidden
+     */
+    protected function checkWriteAccess() {
+        if ($this->hasWriteAccess()) {
+            return;
+        }
+
+        throw new \Sabre\DAV\Exception\Forbidden('You do not have write access to this subscription');
     }
 }

--- a/run_test.sh
+++ b/run_test.sh
@@ -81,7 +81,7 @@ if [ "$SKIP_JAVA" = true ]; then
 fi
 
 (
-  git clone -b test/read-only-mirror-delete-safety https://github.com/vttranlina/twake-calendar-integration-tests.git it-tests
+  git clone https://github.com/linagora/twake-calendar-integration-tests.git it-tests
   cd it-tests
   bash pre-build.sh esn_sabre_test
   mvn clean install -Dapi.version=1.43 -Dtest=com.linagora.dav.sabrev4_7.**

--- a/run_test.sh
+++ b/run_test.sh
@@ -81,7 +81,7 @@ if [ "$SKIP_JAVA" = true ]; then
 fi
 
 (
-  git clone https://github.com/linagora/twake-calendar-integration-tests.git it-tests
+  git clone -b test/read-only-mirror-delete-safety https://github.com/vttranlina/twake-calendar-integration-tests.git it-tests
   cd it-tests
   bash pre-build.sh esn_sabre_test
   mvn clean install -Dapi.version=1.43 -Dtest=com.linagora.dav.sabrev4_7.**


### PR DESCRIPTION
resolve https://github.com/linagora/esn-sabre/issues/347

We have two possible approaches:

* When deleting → return `403 Forbidden` immediately
  or
* When deleting → return `204 No Content`, successfully delete the mirror copy, but keep the original event untouched

I purpose the `403` approach, consistent with the current behavior for `PUT` requests (e.g. updating attendee `PARTSTAT` on a read-only mirror).
