### PR TITLE
ISSUE-358 feat(davacl): restrict principal discovery by current user

### DIFF
--- a/doc/CONFIGURE.md
+++ b/doc/CONFIGURE.md
@@ -42,6 +42,14 @@ Feature flag to enable or disable admin impersonation.
    This flag allows disabling admin impersonation entirely on public Sabre deployments
    to prevent impersonation over the internet.
 
+Feature flag to restrict DAV principal discovery.
+ - PRINCIPAL_PRIVACY
+
+   - unset or `true`: restrict DAV principal discovery to the current principal and its domain principals (default)
+   - `false`: disable the restriction as a fast rollback path
+
+   This prevents DAV clients from enumerating other users or resources and leaking internal principal ids.
+
 Sabre being written in PHP, it supports per-request MongoDB indexes provisioning (defaults to `true`), which can be disabled by setting the SHOULD_CREATE_INDEX environment variable to `false`. This is recommended in production once indexes are provisioned.
 
 ## Scheduling

--- a/esn.php
+++ b/esn.php
@@ -77,7 +77,12 @@ try {
 
 // Backends
 $addressbookBackend = new ESN\CardDAV\Backend\Esn($sabreDb);
+$server = null;
 $principalBackend = new ESN\DAVACL\PrincipalBackend\Mongo($esnDb);
+
+if (principalPrivacyEnabled()) {
+    $principalBackend = new ESN\DAVACL\PrincipalBackend\PrivatePrincipalBackend($principalBackend, currentPrincipalProvider($server));
+}
 
 $schedulingObjectTTLInDays = $dbConfig['schedulingObjectTTLInDays'] ?? 56;
 $calendarBackend = new ESN\CalDAV\Backend\Esn($sabreDb, $principalBackend, $schedulingObjectTTLInDays);
@@ -282,3 +287,23 @@ if (SABRE_ENV === SABRE_ENV_DEV) {
 
 // And off we go!
 $server->exec();
+
+function principalPrivacyEnabled() {
+    $rawPrivacyEnv = getenv('PRINCIPAL_PRIVACY');
+
+    if ($rawPrivacyEnv === false || trim($rawPrivacyEnv) === '') {
+        // Missing or empty env keeps privacy enabled; only an explicit false disables it.
+        return true;
+    }
+
+    $privacyEnabled = filter_var($rawPrivacyEnv, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+    return $privacyEnabled ?? true;
+}
+
+function currentPrincipalProvider(&$server) {
+    return function() use (&$server) {
+        $authPlugin = $server ? $server->getPlugin('auth') : null;
+        return $authPlugin ? $authPlugin->getCurrentPrincipal() : null;
+    };
+}

--- a/lib/DAVACL/PrincipalBackend/PrivatePrincipalBackend.php
+++ b/lib/DAVACL/PrincipalBackend/PrivatePrincipalBackend.php
@@ -3,6 +3,8 @@
 namespace ESN\DAVACL\PrincipalBackend;
 
 // Keep Mongo as the DAO and apply principal privacy only when this backend is selected in esn.php.
+use ESN\Utils\AuthTenant;
+use ESN\Utils\TenantType;
 use Sabre\DAV\PropPatch;
 use Sabre\DAVACL\PrincipalBackend\AbstractBackend;
 
@@ -43,12 +45,16 @@ class PrivatePrincipalBackend extends AbstractBackend {
         return $this->principalBackend->setGroupMemberSet($principal, $members);
     }
 
-    function getPrincipalIdByEmail($email) {
-        return $this->principalBackend->getPrincipalIdByEmail($email);
+    function setAuthTenant(AuthTenant $authTenant) {
+        return $this->principalBackend->setAuthTenant($authTenant);
     }
 
-    function getPrincipalIdByResourceEmail($email) {
-        return $this->principalBackend->getPrincipalIdByResourceEmail($email);
+    function getAuthTenantByEmail(string $email, TenantType $tenantType = TenantType::User): ?AuthTenant {
+        return $this->principalBackend->getAuthTenantByEmail($email, $tenantType);
+    }
+
+    function getAuthTenantByResourceEmail($email, TenantType $tenantType = TenantType::Resources): ?AuthTenant {
+        return $this->principalBackend->getAuthTenantByResourceEmail($email, $tenantType);
     }
 
     function getPrincipalsByPrefix($prefixPath) {

--- a/lib/DAVACL/PrincipalBackend/PrivatePrincipalBackend.php
+++ b/lib/DAVACL/PrincipalBackend/PrivatePrincipalBackend.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace ESN\DAVACL\PrincipalBackend;
+
+// Keep Mongo as the DAO and apply principal privacy only when this backend is selected in esn.php.
+use Sabre\DAV\PropPatch;
+use Sabre\DAVACL\PrincipalBackend\AbstractBackend;
+
+class PrivatePrincipalBackend extends AbstractBackend {
+    const TECHNICAL_PRINCIPAL = 'principals/technicalUser';
+    const DISPLAYNAME = '{DAV:}displayname';
+    const EMAIL_ADDRESS = '{http://sabredav.org/ns}email-address';
+
+    protected $principalBackend;
+    protected $currentPrincipalProvider;
+
+    function __construct(Mongo $principalBackend, $currentPrincipalProvider) {
+        $this->principalBackend = $principalBackend;
+        $this->currentPrincipalProvider = $currentPrincipalProvider;
+    }
+
+    function getPrincipalByPath($path) {
+        return $this->principalBackend->getPrincipalByPath($path);
+    }
+
+    function findByUri($uri, $principalPrefix) {
+        return $this->principalBackend->findByUri($uri, $principalPrefix);
+    }
+
+    function updatePrincipal($path, PropPatch $propPatch) {
+        return $this->principalBackend->updatePrincipal($path, $propPatch);
+    }
+
+    function getGroupMemberSet($principal) {
+        return $this->principalBackend->getGroupMemberSet($principal);
+    }
+
+    function getGroupMembership($principal) {
+        return $this->principalBackend->getGroupMembership($principal);
+    }
+
+    function setGroupMemberSet($principal, array $members) {
+        return $this->principalBackend->setGroupMemberSet($principal, $members);
+    }
+
+    function getPrincipalIdByEmail($email) {
+        return $this->principalBackend->getPrincipalIdByEmail($email);
+    }
+
+    function getPrincipalIdByResourceEmail($email) {
+        return $this->principalBackend->getPrincipalIdByResourceEmail($email);
+    }
+
+    function getPrincipalsByPrefix($prefixPath) {
+        if ($this->isTechnicalPrincipal()) {
+            return $this->principalBackend->getPrincipalsByPrefix($prefixPath);
+        }
+
+        $principals = [];
+
+        foreach ($this->visiblePrincipalPaths($prefixPath) as $principalPath) {
+            $principal = $this->principalBackend->getPrincipalByPath($principalPath);
+
+            if ($principal) {
+                $principals[] = $principal;
+            }
+        }
+
+        return $principals;
+    }
+
+    function searchPrincipals($prefixPath, array $searchProperties, $test = 'allof') {
+        if ($this->isTechnicalPrincipal()) {
+            return $this->principalBackend->searchPrincipals($prefixPath, $searchProperties, $test);
+        }
+
+        $principals = [];
+
+        foreach ($this->visiblePrincipalPaths($prefixPath) as $principalPath) {
+            $principal = $this->principalBackend->getPrincipalByPath($principalPath);
+
+            if ($principal && $this->principalMatches($principal, $searchProperties, $test)) {
+                $principals[$principal['uri']] = $principal['uri'];
+            }
+        }
+
+        return array_values($principals);
+    }
+
+    private function visiblePrincipalPaths($prefixPath) {
+        $prefixPath = $this->normalizePrincipalUri($prefixPath);
+        $currentPrincipal = $this->currentPrincipalPath();
+
+        if (!$currentPrincipal) {
+            return [];
+        }
+
+        if (str_starts_with($currentPrincipal, $prefixPath . '/')) {
+            return [$currentPrincipal];
+        }
+
+        $parts = explode('/', $currentPrincipal);
+        if ($prefixPath === 'principals/domains' && count($parts) === 3 && $parts[1] === 'users') {
+            return $this->principalBackend->getGroupMembership($currentPrincipal);
+        }
+        return [];
+    }
+
+    private function principalMatches($principal, array $searchProperties, $test) {
+        // RFC3744 principal-property-search supports "allof" and "anyof". Treat
+        // unknown test modes as non-matching instead of falling back to a broader
+        // result set.
+        if (!in_array($test, ['allof', 'anyof'], true)) {
+            return false;
+        }
+
+        $matches = [];
+
+        foreach ($searchProperties as $property => $value) {
+            $match = $this->propertyMatches($principal, $property, $value);
+
+            if ($match !== null) {
+                $matches[] = $match;
+            }
+        }
+
+        if (empty($matches)) {
+            return false;
+        }
+
+        if ($test === 'anyof') {
+            return in_array(true, $matches, true);
+        }
+
+        return !in_array(false, $matches, true);
+    }
+
+    private function propertyMatches($principal, $property, $value) {
+        if ($property === self::DISPLAYNAME && isset($principal[$property])) {
+            return stripos($principal[$property], $value) !== false;
+        }
+
+        if ($property === self::EMAIL_ADDRESS && isset($principal[$property])) {
+            [$possibleResourceId] = explode('@', $value);
+            return strcasecmp($principal[$property], $value) === 0 ||
+                $principal['uri'] === 'principals/resources/' . $possibleResourceId;
+        }
+
+        return null;
+    }
+
+    private function isTechnicalPrincipal() {
+        return $this->currentPrincipalPath() === self::TECHNICAL_PRINCIPAL;
+    }
+
+    private function currentPrincipalPath() {
+        if (!$this->currentPrincipalProvider) {
+            return null;
+        }
+
+        $principal = call_user_func($this->currentPrincipalProvider);
+
+        return $principal ? $this->normalizePrincipalUri($principal) : null;
+    }
+
+    private function normalizePrincipalUri($principalUri) {
+        return trim($principalUri, '/');
+    }
+}

--- a/run_test.sh
+++ b/run_test.sh
@@ -55,7 +55,7 @@ cleanup() {
 trap cleanup EXIT  # finally: sera exécuté *quoi qu'il arrive*
 
 javatest() {
-    git clone -b tmp/forIssue358 https://github.com/vttranlina/twake-calendar-integration-tests.git it-tests ||  exit 1
+    git clone https://github.com/linagora/twake-calendar-integration-tests.git it-tests ||  exit 1
     cd it-tests || exit 1
     bash pre-build.sh esn_sabre_test || exit 1
     mvn clean install -Dapi.version=1.43 -Dtest=com.linagora.dav.sabrev4_7.** || exit 1

--- a/run_test.sh
+++ b/run_test.sh
@@ -55,7 +55,7 @@ cleanup() {
 trap cleanup EXIT  # finally: sera exécuté *quoi qu'il arrive*
 
 javatest() {
-    git clone https://github.com/linagora/twake-calendar-integration-tests.git it-tests ||  exit 1
+    git clone -b tmp/forIssue358 https://github.com/vttranlina/twake-calendar-integration-tests.git it-tests ||  exit 1
     cd it-tests || exit 1
     bash pre-build.sh esn_sabre_test || exit 1
     mvn clean install -Dapi.version=1.43 -Dtest=com.linagora.dav.sabrev4_7.** || exit 1

--- a/tests/DAVACL/PrincipalBackend/PrivatePrincipalBackendTest.php
+++ b/tests/DAVACL/PrincipalBackend/PrivatePrincipalBackendTest.php
@@ -200,25 +200,32 @@ class PrivatePrincipalBackendTest extends \PHPUnit\Framework\TestCase {
     function testShouldExposeCustomMongoLookupMethods() {
         $mongo = $this->getMockBuilder(Mongo::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['getPrincipalIdByEmail', 'getPrincipalIdByResourceEmail'])
+            ->onlyMethods(['setAuthTenant', 'getAuthTenantByEmail', 'getAuthTenantByResourceEmail'])
             ->getMock();
 
+        $tenant = new \ESN\Utils\AuthTenant('123', 'domain-id');
+        $resourceTenant = new \ESN\Utils\AuthTenant('456', 'domain-id', \ESN\Utils\TenantType::Resources);
+
         $mongo->expects($this->once())
-            ->method('getPrincipalIdByEmail')
+            ->method('setAuthTenant')
+            ->with($tenant);
+        $mongo->expects($this->once())
+            ->method('getAuthTenantByEmail')
             ->with('user@example.com')
-            ->willReturn('123');
+            ->willReturn($tenant);
         $mongo->expects($this->once())
-            ->method('getPrincipalIdByResourceEmail')
+            ->method('getAuthTenantByResourceEmail')
             ->with('resource@example.com')
-            ->willReturn('456');
+            ->willReturn($resourceTenant);
 
         $backend = new PrivatePrincipalBackend($mongo, function() {
             return 'principals/users/123';
         });
 
-        $this->assertTrue(method_exists($backend, 'getPrincipalIdByEmail'));
-        $this->assertEquals('123', $backend->getPrincipalIdByEmail('user@example.com'));
-        $this->assertEquals('456', $backend->getPrincipalIdByResourceEmail('resource@example.com'));
+        $this->assertTrue(method_exists($backend, 'getAuthTenantByEmail'));
+        $this->assertNull($backend->setAuthTenant($tenant));
+        $this->assertSame($tenant, $backend->getAuthTenantByEmail('user@example.com'));
+        $this->assertSame($resourceTenant, $backend->getAuthTenantByResourceEmail('resource@example.com'));
     }
 
     private function newPrivateBackend($currentPrincipal) {

--- a/tests/DAVACL/PrincipalBackend/PrivatePrincipalBackendTest.php
+++ b/tests/DAVACL/PrincipalBackend/PrivatePrincipalBackendTest.php
@@ -1,0 +1,299 @@
+<?php
+
+namespace ESN\DAVACL\PrincipalBackend;
+
+class PrivatePrincipalBackendTest extends \PHPUnit\Framework\TestCase {
+    const USER_PRINCIPAL = 'principals/users/123';
+    const OTHER_USER_PRINCIPAL = 'principals/users/456';
+    const DOMAIN_PRINCIPAL = 'principals/domains/789';
+    const OTHER_DOMAIN_PRINCIPAL = 'principals/domains/999';
+    const RESOURCE_PRINCIPAL = 'principals/resources/resource-1';
+    const OTHER_RESOURCE_PRINCIPAL = 'principals/resources/resource-2';
+
+    function testGetPrincipalsByPrefixShouldExposeOnlyCurrentUserAndCurrentUserDomains() {
+        $backend = $this->newPrivateBackend(self::USER_PRINCIPAL);
+
+        $this->assertEquals(
+            [$this->principal(self::USER_PRINCIPAL, 'Bob User', 'bob@example.com')],
+            $backend->getPrincipalsByPrefix('principals/users')
+        );
+        $this->assertEquals(
+            [$this->principal(self::DOMAIN_PRINCIPAL, 'Acme Domain')],
+            $backend->getPrincipalsByPrefix('principals/domains')
+        );
+        $this->assertEquals([], $backend->getPrincipalsByPrefix('principals/resources'));
+    }
+
+    function testGetPrincipalsByPrefixShouldDelegateForTechnicalPrincipal() {
+        $mongo = $this->getMockBuilder(Mongo::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getPrincipalsByPrefix'])
+            ->getMock();
+
+        $mongo->expects($this->once())
+            ->method('getPrincipalsByPrefix')
+            ->with('principals/users')
+            ->willReturn([['uri' => 'principals/users/123'], ['uri' => 'principals/users/456']]);
+
+        $backend = new PrivatePrincipalBackend($mongo, function() {
+            return 'principals/technicalUser';
+        });
+
+        $this->assertEquals(
+            [['uri' => 'principals/users/123'], ['uri' => 'principals/users/456']],
+            $backend->getPrincipalsByPrefix('principals/users')
+        );
+    }
+
+    function testSearchPrincipalsShouldSearchOnlyCurrentUserAndCurrentUserDomains() {
+        $backend = $this->newPrivateBackend(self::USER_PRINCIPAL);
+
+        $this->assertEquals(
+            [self::USER_PRINCIPAL],
+            $backend->searchPrincipals('principals/users', ['{DAV:}displayname' => 'Bob'])
+        );
+        $this->assertEquals(
+            [],
+            $backend->searchPrincipals('principals/users', ['{DAV:}displayname' => 'Alice'])
+        );
+        $this->assertEquals(
+            [self::DOMAIN_PRINCIPAL],
+            $backend->searchPrincipals('principals/domains', ['{DAV:}displayname' => 'Acme'])
+        );
+        $this->assertEquals(
+            [],
+            $backend->searchPrincipals('principals/domains', ['{DAV:}displayname' => 'Other'])
+        );
+        $this->assertEquals(
+            [],
+            $backend->searchPrincipals(
+                'principals/resources',
+                ['{http://sabredav.org/ns}email-address' => 'resource-1@example.com']
+            )
+        );
+    }
+
+    function testGetPrincipalsByPrefixShouldExposeOnlyCurrentResourceForResourcePrincipal() {
+        $backend = $this->newPrivateBackend(self::RESOURCE_PRINCIPAL);
+
+        $this->assertEquals(
+            [$this->principal(self::RESOURCE_PRINCIPAL, 'Room One', 'resource-1@example.com')],
+            $backend->getPrincipalsByPrefix('principals/resources')
+        );
+        $this->assertEquals([], $backend->getPrincipalsByPrefix('principals/users'));
+        $this->assertEquals([], $backend->getPrincipalsByPrefix('principals/domains'));
+    }
+
+    function testSearchPrincipalsShouldExposeOnlyCurrentResourceForResourcePrincipal() {
+        $backend = $this->newPrivateBackend(self::RESOURCE_PRINCIPAL);
+
+        $this->assertEquals(
+            [self::RESOURCE_PRINCIPAL],
+            $backend->searchPrincipals(
+                'principals/resources',
+                ['{http://sabredav.org/ns}email-address' => 'resource-1@example.com']
+            )
+        );
+        $this->assertEquals(
+            [],
+            $backend->searchPrincipals(
+                'principals/resources',
+                ['{http://sabredav.org/ns}email-address' => 'resource-2@example.com']
+            )
+        );
+        $this->assertEquals(
+            [],
+            $backend->searchPrincipals('principals/users', ['{DAV:}displayname' => 'Bob'])
+        );
+    }
+
+    function testSearchPrincipalsShouldDelegateForTechnicalPrincipal() {
+        $searchProperties = ['{DAV:}displayname' => 'Bob'];
+        $mongo = $this->getMockBuilder(Mongo::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['searchPrincipals', 'getPrincipalByPath'])
+            ->getMock();
+
+        $mongo->expects($this->once())
+            ->method('searchPrincipals')
+            ->with('principals/users', $searchProperties, 'anyof')
+            ->willReturn(['principals/users/123']);
+        $mongo->expects($this->never())
+            ->method('getPrincipalByPath');
+
+        $backend = new PrivatePrincipalBackend($mongo, function() {
+            return 'principals/technicalUser';
+        });
+
+        $this->assertEquals(
+            ['principals/users/123'],
+            $backend->searchPrincipals('principals/users', $searchProperties, 'anyof')
+        );
+    }
+
+    function testGetPrincipalsByPrefixShouldReturnNothingWithoutCurrentPrincipal() {
+        $backend = $this->newPrivateBackend(null);
+
+        $this->assertEquals([], $backend->getPrincipalsByPrefix('principals/users'));
+        $this->assertEquals([], $backend->getPrincipalsByPrefix('principals/domains'));
+        $this->assertEquals([], $backend->getPrincipalsByPrefix('principals/resources'));
+        $this->assertEquals(
+            [],
+            $backend->searchPrincipals('principals/users', ['{DAV:}displayname' => 'Bob'])
+        );
+    }
+
+    function testSearchPrincipalsShouldHonorAllofAndAnyofForVisiblePrincipal() {
+        $backend = $this->newPrivateBackend(self::USER_PRINCIPAL);
+
+        $this->assertEquals(
+            [self::USER_PRINCIPAL],
+            $backend->searchPrincipals(
+                'principals/users',
+                [
+                    '{DAV:}displayname' => 'Bob',
+                    '{http://sabredav.org/ns}email-address' => 'bob@example.com'
+                ]
+            )
+        );
+        $this->assertEquals(
+            [],
+            $backend->searchPrincipals(
+                'principals/users',
+                [
+                    '{DAV:}displayname' => 'Bob',
+                    '{http://sabredav.org/ns}email-address' => 'alice@example.com'
+                ]
+            )
+        );
+        $this->assertEquals(
+            [self::USER_PRINCIPAL],
+            $backend->searchPrincipals(
+                'principals/users',
+                [
+                    '{DAV:}displayname' => 'Bob',
+                    '{http://sabredav.org/ns}email-address' => 'alice@example.com'
+                ],
+                'anyof'
+            )
+        );
+    }
+
+    function testFindByUriShouldDelegateExactLookup() {
+        $mongo = $this->getMockBuilder(Mongo::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['findByUri'])
+            ->getMock();
+
+        $mongo->expects($this->once())
+            ->method('findByUri')
+            ->with('mailto:user@example.com', 'principals/users')
+            ->willReturn('principals/users/123');
+
+        $backend = new PrivatePrincipalBackend($mongo, function() {
+            return 'principals/users/456';
+        });
+
+        $this->assertEquals('principals/users/123', $backend->findByUri('mailto:user@example.com', 'principals/users'));
+    }
+
+    function testShouldExposeCustomMongoLookupMethods() {
+        $mongo = $this->getMockBuilder(Mongo::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getPrincipalIdByEmail', 'getPrincipalIdByResourceEmail'])
+            ->getMock();
+
+        $mongo->expects($this->once())
+            ->method('getPrincipalIdByEmail')
+            ->with('user@example.com')
+            ->willReturn('123');
+        $mongo->expects($this->once())
+            ->method('getPrincipalIdByResourceEmail')
+            ->with('resource@example.com')
+            ->willReturn('456');
+
+        $backend = new PrivatePrincipalBackend($mongo, function() {
+            return 'principals/users/123';
+        });
+
+        $this->assertTrue(method_exists($backend, 'getPrincipalIdByEmail'));
+        $this->assertEquals('123', $backend->getPrincipalIdByEmail('user@example.com'));
+        $this->assertEquals('456', $backend->getPrincipalIdByResourceEmail('resource@example.com'));
+    }
+
+    private function newPrivateBackend($currentPrincipal) {
+        return new PrivatePrincipalBackend($this->principalStore(), function() use ($currentPrincipal) {
+            return $currentPrincipal;
+        });
+    }
+
+    private function principalStore() {
+        return new PrivatePrincipalBackendTestMongo(
+            [
+                self::USER_PRINCIPAL => $this->principal(self::USER_PRINCIPAL, 'Bob User', 'bob@example.com'),
+                self::OTHER_USER_PRINCIPAL => $this->principal(self::OTHER_USER_PRINCIPAL, 'Alice User', 'alice@example.com'),
+                self::DOMAIN_PRINCIPAL => $this->principal(self::DOMAIN_PRINCIPAL, 'Acme Domain'),
+                self::OTHER_DOMAIN_PRINCIPAL => $this->principal(self::OTHER_DOMAIN_PRINCIPAL, 'Other Domain'),
+                self::RESOURCE_PRINCIPAL => $this->principal(self::RESOURCE_PRINCIPAL, 'Room One', 'resource-1@example.com'),
+                self::OTHER_RESOURCE_PRINCIPAL => $this->principal(self::OTHER_RESOURCE_PRINCIPAL, 'Room Two', 'resource-2@example.com')
+            ],
+            [
+                self::USER_PRINCIPAL => [self::DOMAIN_PRINCIPAL],
+                self::OTHER_USER_PRINCIPAL => [self::OTHER_DOMAIN_PRINCIPAL]
+            ]
+        );
+    }
+
+    private function principal($uri, $displayName, $email = null) {
+        $principal = [
+            'uri' => $uri,
+            '{DAV:}displayname' => $displayName
+        ];
+
+        if ($email !== null) {
+            $principal['{http://sabredav.org/ns}email-address'] = $email;
+        }
+
+        return $principal;
+    }
+}
+
+class PrivatePrincipalBackendTestMongo extends Mongo {
+    private $principalsByPath;
+    private $memberships;
+
+    function __construct($principalsByPath, $memberships) {
+        $this->principalsByPath = $principalsByPath;
+        $this->memberships = $memberships;
+    }
+
+    function getPrincipalsByPrefix($prefixPath) {
+        $principals = [];
+
+        foreach ($this->principalsByPath as $principal) {
+            if (str_starts_with($principal['uri'], $prefixPath . '/')) {
+                $principals[] = $principal;
+            }
+        }
+
+        return $principals;
+    }
+
+    function getPrincipalByPath($path) {
+        return $this->principalsByPath[$path] ?? null;
+    }
+
+    function searchPrincipals($prefixPath, array $searchProperties, $test = 'allof') {
+        $result = [];
+
+        foreach ($this->getPrincipalsByPrefix($prefixPath) as $principal) {
+            $result[] = $principal['uri'];
+        }
+
+        return $result;
+    }
+
+    function getGroupMembership($principal) {
+        return $this->memberships[$principal] ?? [];
+    }
+}


### PR DESCRIPTION
Wrap the Mongo principal backend to restrict principal discovery without changing existing exact lookups. With `PRINCIPAL_PRIVACY` enabled by default, `getPrincipalsByPrefix` and `searchPrincipals` only expose the current principal and its domains, preventing DAV clients from enumerating other users or resources while keeping `PRINCIPAL_PRIVACY=false` as a rollback path.

relate https://github.com/linagora/esn-sabre/issues/358