### PR TITLE
fix(auth): initialize calendar root before auth listeners

### DIFF
--- a/esn.php
+++ b/esn.php
@@ -108,9 +108,10 @@ $server->addPlugin($loggerPlugin);
 // Auth backend
 $authBackend = new ESN\DAV\Auth\Backend\Esn($config['esn']['apiRoot'], $config['webserver']['realm'], $principalBackend, $server, SABRE_ENV === SABRE_ENV_DEV);
 $server->on('auth:success',
-            function(AuthTenant $authTenant) use ($principalBackend) {
+            function(AuthTenant $authTenant) use ($principalBackend, $calendarRoot) {
                 $principalBackend->setAuthTenant($authTenant);
-            });
+                $calendarRoot->setAuthTenant($authTenant);
+            }, 1);
 
 // listener
 $server->on("auth:success", function($authTenant) use ($addressbookBackend) {
@@ -127,10 +128,6 @@ $server->on("auth:success", function($authTenant) use ($calendarBackend) {
 
     return $calendarBackend->getCalendarsForUser((string) $authTenant->getPrincipal());
 });
-$server->on('auth:success',
-            function(AuthTenant $authTenant) use ($calendarRoot) {
-                $calendarRoot->setAuthTenant($authTenant);
-            });
 
 // Add stack trace to HTML response in dev mode
 if (SABRE_ENV === SABRE_ENV_DEV) {


### PR DESCRIPTION
Regarding pr
- https://github.com/linagora/esn-sabre/pull/365

we missed one case not covered by the synchronized scheduling integration tests: admin impersonation of a resource fails on the first request with `401`:

`Cross-domain calendar access is not allowed: null $authTenant`

Root cause: the `auth:success` listeners run in this order:

```php
principalBackend->setAuthTenant(...)
addressbookBackend->getAddressBooksForUser(...)
calendarBackend->getCalendarsForUser(...)
calendarRoot->setAuthTenant(...)
```

For resource principals, `calendarBackend->getCalendarsForUser(...)` may lazy-create the resource default calendar. On the first request, `CalendarRoot` has not received `authTenant` yet because `calendarRoot->setAuthTenant(...)` runs later.

Proposed fix: move `calendarRoot->setAuthTenant($authTenant)` into the early listener together with `principalBackend->setAuthTenant($authTenant)`.