### PR TITLE
feat(schedule): Recipient-specific email VALARM scheduling

### DIFF
--- a/doc/ALARM-SCHEDULING.md
+++ b/doc/ALARM-SCHEDULING.md
@@ -51,6 +51,11 @@ For each attendee copy, esn-sabre MUST:
 The organizer source event MUST remain unchanged. Its `VALARM` components keep
 their complete recipient lists.
 
+The organizer MAY target himself in an organizer-managed email alarm by listing
+his own mail address in the alarm `ATTENDEE` properties. The organizer MAY also
+use a dedicated `VALARM` component for himself when his reminder trigger differs
+from other attendees.
+
 This prevents:
 
 - an alarm addressed to Alice from being cloned to all event attendees;

--- a/doc/ALARM-SCHEDULING.md
+++ b/doc/ALARM-SCHEDULING.md
@@ -1,0 +1,217 @@
+# Alarm Scheduling Specification
+
+## Scope and references
+
+This document defines Twake Calendar behavior for scheduling `ACTION:EMAIL`
+`VALARM` components between an organizer and event attendees.
+
+This design follows the iCalendar model from
+[RFC 5545 Section 3.6.1](https://www.rfc-editor.org/rfc/rfc5545#section-3.6.1)
+and
+[RFC 5545 Section 3.6.6](https://www.rfc-editor.org/rfc/rfc5545#section-3.6.6):
+a `VEVENT` can contain multiple `VALARM` components, and an `ACTION:EMAIL`
+`VALARM` can contain multiple `ATTENDEE` properties. RFC 9074 Section 4 extends
+`VALARM` with an optional `UID`.
+
+The key words **MUST**, **MUST NOT**, **SHOULD**, and **MAY** describe product
+requirements. They do not redefine iCalendar RFC requirements.
+
+## Feature flag
+
+The complete behavior described in this document is guarded by:
+
+```text
+SABRE_EMAIL_VALARM_RECIPIENT_SCHEDULING=true
+```
+
+When the flag is enabled, esn-sabre MUST apply all rules in this document.
+
+## Concepts
+
+- **Source event**: the event stored in the organizer's calendar.
+- **Attendee copy**: the scheduled event copy stored in one attendee's calendar.
+- **Organizer-managed alarm**: an alarm coming from the organizer source event.
+- **Personal alarm**: an alarm created only in an attendee copy by that calendar
+  owner.
+- **Current recipient**: the attendee receiving one iTIP scheduling message.
+
+## Recipient projection
+
+When the organizer schedules an event, each organizer-managed `ACTION:EMAIL`
+`VALARM` MUST be copied only to event attendees explicitly listed in that
+alarm's own `ATTENDEE` properties.
+
+For each attendee copy, esn-sabre MUST:
+
+1. Select organizer-managed email alarms listing the current recipient.
+2. Keep each selected alarm as a separate `VALARM` component.
+3. Remove every alarm `ATTENDEE` except the current recipient.
+4. Omit alarms that do not list the current recipient.
+
+The organizer source event MUST remain unchanged. Its `VALARM` components keep
+their complete recipient lists.
+
+This prevents:
+
+- an alarm addressed to Alice from being cloned to all event attendees;
+- an attendee receiving an alarm only because they are listed at event level;
+- organizer aliases or unrelated recipient addresses leaking into attendee
+  copies.
+
+Assume Bob is the organizer. The source event contains:
+
+```ics
+BEGIN:VALARM
+UID:alarm-11111111-1111-4111-8111-111111111111
+ACTION:EMAIL
+DESCRIPTION:This is an event reminder
+SUMMARY:Alarm notification
+ATTENDEE:mailto:bob@example.org
+ATTENDEE:mailto:alice@example.org
+ATTENDEE:mailto:cedric@example.org
+TRIGGER:-PT10M
+END:VALARM
+```
+
+Alice's copy contains only Alice as alarm recipient:
+
+```ics
+BEGIN:VALARM
+UID:alarm-11111111-1111-4111-8111-111111111111
+ACTION:EMAIL
+DESCRIPTION:This is an event reminder
+SUMMARY:Alarm notification
+ATTENDEE:mailto:alice@example.org
+TRIGGER:-PT10M
+END:VALARM
+```
+
+Cedric's copy contains the same alarm with only
+`ATTENDEE:mailto:cedric@example.org`. Bob's source keeps all three recipients.
+
+## Multiple alarms
+
+A `VEVENT` MAY contain multiple `VALARM` components. Each `VALARM` is
+independent and MUST be projected independently.
+
+This supports different trigger times for different recipients:
+
+```ics
+BEGIN:VALARM
+UID:alarm-22222222-2222-4222-8222-222222222222
+ACTION:EMAIL
+DESCRIPTION:This is an event reminder
+SUMMARY:Alarm notification
+ATTENDEE:mailto:alice@example.org
+ATTENDEE:mailto:cedric@example.org
+TRIGGER:-PT5M
+END:VALARM
+BEGIN:VALARM
+UID:alarm-33333333-3333-4333-8333-333333333333
+ACTION:EMAIL
+DESCRIPTION:This is an event reminder
+SUMMARY:Alarm notification
+ATTENDEE:mailto:bob@example.org
+TRIGGER:-PT10M
+END:VALARM
+```
+
+Alice and Cedric receive the five-minute alarm projected to themselves. Bob
+keeps both components in the source event, but only the alarm addressed to Bob is
+effective for Bob as calendar owner.
+
+If two different `VALARM` components both list Alice, Alice's copy MUST contain
+both alarms. Two alarms at five and ten minutes are two intentional
+notifications, not conflicting versions of one alarm.
+
+## Alarm execution
+
+Scheduling and execution are separate concerns:
+
+- esn-sabre projects organizer-managed alarms into addressed attendee calendars;
+- the alarm service evaluates a calendar object for its calendar owner;
+- while evaluating the organizer source event, email addresses belonging to
+  other event attendees MUST NOT be executed from the organizer's calendar;
+- a non-attendee address, such as the organizer's personal alias, MAY be
+  executed from the organizer's calendar when explicitly listed in the alarm.
+
+Therefore, an alarm addressed to Alice is executed from Alice's attendee copy,
+not once from Alice's copy and once again from Bob's source event.
+
+## Organizer updates and merge
+
+The organizer is authoritative for organizer-managed alarms. On organizer
+updates, esn-sabre MUST replace the previous organizer-managed projection in
+each attendee copy with the latest projection from the source event.
+
+For each attendee and each event occurrence, the resulting alarm set is:
+
+```text
+latest organizer-managed alarms projected to this attendee
++ existing personal alarms created in this attendee copy
+```
+
+Update rules:
+
+- adding an attendee to both the event and an alarm adds the projected alarm to
+  that attendee copy;
+- adding an attendee only to the event does not give that attendee an email
+  alarm;
+- adding a recipient to an existing alarm propagates that alarm to the new
+  recipient;
+- removing a recipient from an alarm removes the corresponding
+  organizer-managed alarm from that attendee copy;
+- changing an organizer-managed alarm, including its trigger, propagates the new
+  value to every recipient still listed in the alarm;
+- deleting an organizer-managed alarm removes its projections from attendee
+  copies;
+- personal alarms created in attendee copies MUST be preserved.
+
+The merge MUST NOT keep an outdated organizer trigger instead of the new
+organizer value. It also MUST NOT delete a separate personal alarm merely
+because an organizer alarm has a similar action or trigger.
+
+## Personal alarms
+
+An attendee MAY create, update, or remove personal alarms on their own event
+copy. A personal alarm:
+
+- MUST remain local to that attendee's calendar;
+- MUST NOT propagate to the organizer or other attendees;
+- MAY target the attendee's primary address or another personal address;
+- MUST be preserved when organizer-managed alarms are updated;
+- when created by a Twake client, MUST use a UID different from every
+  organizer-managed alarm on the event.
+
+Editing an organizer-managed alarm and creating a personal alarm are different
+operations. Twake clients SHOULD create a new `VALARM` with a new UID when a
+user chooses a personal reminder instead of mutating the organizer-managed
+component into a personal one.
+
+## UID rules
+
+`VALARM` UID is optional according to RFC 9074 Section 4. Twake Calendar accepts
+alarms without UID for compatibility.
+
+When `SABRE_EMAIL_VALARM_RECIPIENT_SCHEDULING` is enabled, esn-sabre MUST
+generate a UID for every `VALARM` missing one before persisting and scheduling
+the event. Generated UIDs MUST use the `alarm-{uuid}` format with a UUID v4
+value. If the client already provides a UID, esn-sabre MUST preserve it.
+
+UID provides stable identity for matching alarm updates. It does not express
+ownership by itself:
+
+- alarms projected from the organizer source are organizer-managed;
+- alarms created only in an attendee copy are personal.
+
+UID SHOULD be used to match an old organizer-managed alarm with its updated
+version. Legacy UID-less alarms MAY be compared against previous and current
+organizer projections, but identical UID-less organizer and personal alarms are
+inherently ambiguous. Clients avoid that ambiguity by assigning a new UID to
+personal alarms.
+
+## Recurring events
+
+Projection and merge rules apply independently to the master event and each
+recurrence override. Matching MUST use the event occurrence identity so that an
+alarm from one occurrence is not attached to another occurrence.

--- a/doc/CONFIGURE.md
+++ b/doc/CONFIGURE.md
@@ -76,6 +76,13 @@ If the event attendee count is greater than or equal to `TW_CAL_REPLY_PROPAGATIO
 - Default: enabled. Unset, empty, or invalid values are treated as enabled.
 - Set to `false`, `0`, `off`, or `no` to disable.
 
+`SABRE_EMAIL_VALARM_RECIPIENT_SCHEDULING` controls recipient-aware scheduling for `ACTION:EMAIL` `VALARM` components.
+
+- Default: enabled. Unset, empty, or invalid values are treated as enabled.
+- Set to `false`, `0`, `off`, or `no` to disable.
+
+When enabled, Sabre sends each attendee only the email alarms that explicitly list them as an alarm recipient, preserves attendee-local alarms during organizer updates, See [Alarm Scheduling Specification](ALARM-SCHEDULING.md) for the complete behavior.
+
 ## Nginx rate limiting
 
 The embedded Nginx is configured with `ngx_http_limit_req_module` to protect the CalDAV server from request flooding. Three ENV variables control the behaviour:

--- a/lib/CalDAV/Schedule/AMQPSchedulePlugin.php
+++ b/lib/CalDAV/Schedule/AMQPSchedulePlugin.php
@@ -193,6 +193,10 @@ class AMQPSchedulePlugin extends Plugin {
             return;
         }
 
+        if ($this->shouldEnableEmailValarmRecipientScheduling() && $this->ensureValarmUids($vCal)) {
+            $modified = true;
+        }
+
         $addresses = $this->fetchCalendarOwnerAddresses($calendarPath);
 
         $this->currentOldMessage = null;

--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -31,8 +31,10 @@ use Sabre\VObject\Reader;
 class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
     private const DEFAULT_REPLY_PROPAGATION_THRESHOLD = 200;
     private const PRESERVABLE_RECIPIENT_LOCAL_PROPERTIES = ['VALARM', 'TRANSP', 'CLASS'];
+    private const PRESERVABLE_RECIPIENT_LOCAL_PROPERTIES_WITH_MANAGED_ALARMS = ['TRANSP', 'CLASS'];
     private const FORBIDDEN_ATTENDEE_CHANGE_PROPERTIES = ['DTSTART', 'DTEND', 'LOCATION', 'SUMMARY', 'ORGANIZER'];
     private const ENFORCE_RFC_6638_ENV = 'SABRE_ENFORCE_RFC_6638';
+    private const EMAIL_VALARM_RECIPIENT_SCHEDULING_ENV = 'SABRE_EMAIL_VALARM_RECIPIENT_SCHEDULING';
 
     private $logger;
     private $principalBackend;
@@ -300,7 +302,14 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
                 continue;
             }
 
-            foreach (self::PRESERVABLE_RECIPIENT_LOCAL_PROPERTIES as $property) {
+            if ($this->shouldEnableEmailValarmRecipientScheduling()) {
+                $this->preserveRecipientLocalVALARMs($oldEvent, $newEvent);
+                $preservableProperties = self::PRESERVABLE_RECIPIENT_LOCAL_PROPERTIES_WITH_MANAGED_ALARMS;
+            } else {
+                $preservableProperties = self::PRESERVABLE_RECIPIENT_LOCAL_PROPERTIES;
+            }
+
+            foreach ($preservableProperties as $property) {
                 $newEvent->remove($property);
 
                 foreach ($oldEvent->select($property) as $oldProperty) {
@@ -310,6 +319,95 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
         }
 
         $oldObject->destroy();
+    }
+
+    // Email VALARM recipient scheduling
+    protected function shouldEnableEmailValarmRecipientScheduling(): bool {
+        return $this->envBoolean(self::EMAIL_VALARM_RECIPIENT_SCHEDULING_ENV, true);
+    }
+
+    protected function ensureValarmUids(VCalendar $calendarObject): bool {
+        $modified = false;
+
+        foreach ($calendarObject->select('VEVENT') as $event) {
+            foreach ($event->select('VALARM') as $alarm) {
+                if (!isset($alarm->UID) || trim($alarm->UID->getValue()) === '') {
+                    $alarm->UID = 'alarm-' . \Sabre\DAV\UUIDUtil::getUUID();
+                    $modified = true;
+                }
+            }
+        }
+
+        return $modified;
+    }
+
+    private function preserveRecipientLocalVALARMs($oldEvent, $newEvent): void {
+        $newEmailAlarms = array_map(fn ($alarm) => clone $alarm, array_filter($newEvent->select('VALARM'), [$this, 'isEmailAlarm']));
+
+        $newEvent->remove('VALARM');
+        foreach ($newEmailAlarms as $alarm) {
+            $newEvent->add($alarm);
+        }
+
+        $newEmailAlarmUids = array_filter(array_map(fn ($alarm) => isset($alarm->UID) ? $alarm->UID->getValue() : null, $newEmailAlarms));
+        $eventAttendees = array_map(fn ($attendee) => strtolower($attendee->getNormalizedValue()), $newEvent->select('ATTENDEE'));
+
+        foreach ($oldEvent->select('VALARM') as $oldAlarm) {
+            if ($this->isEmailAlarm($oldAlarm) && $this->isOrganizerManagedEmailAlarm($oldAlarm, $newEmailAlarmUids, $eventAttendees)) {
+                continue;
+            }
+
+            $newEvent->add(clone $oldAlarm);
+        }
+    }
+
+    private function isEmailAlarm($alarm): bool {
+        return isset($alarm->ACTION) && strcasecmp($alarm->ACTION->getValue(), 'EMAIL') === 0;
+    }
+
+    private function isOrganizerManagedEmailAlarm($alarm, array $newEmailAlarmUids, array $eventAttendees): bool {
+        if (isset($alarm->UID) && in_array($alarm->UID->getValue(), $newEmailAlarmUids, true)) {
+            return true;
+        }
+
+        $alarmAttendees = array_map(fn ($attendee) => strtolower($attendee->getNormalizedValue()), $alarm->select('ATTENDEE'));
+
+        return !empty($alarmAttendees) && empty(array_diff($alarmAttendees, $eventAttendees));
+    }
+
+    /**
+     * EMAIL alarms are recipient-specific: only deliver alarms that explicitly
+     * name the iTIP recipient in their own ATTENDEE properties.
+     */
+    private function filterEmailAlarmsForRecipient(ITip\Message $message, VCalendar $sourceCalendar): void {
+        $sourceEvents = CalendarObjectHelper::indexEventsByRecurrenceKey($sourceCalendar);
+
+        foreach ($message->message->select('VEVENT') as $vevent) {
+            $sourceEvent = $sourceEvents[CalendarObjectHelper::recurrenceKey($vevent)] ?? null;
+
+            // The broker may rewrite VALARM attendees to the message recipient,
+            // so rebuild EMAIL alarms from the organizer's original calendar.
+            foreach (array_filter($vevent->select('VALARM'), [$this, 'isEmailAlarm']) as $alarm) {
+                $vevent->remove($alarm);
+            }
+
+            if (!$sourceEvent) {
+                continue;
+            }
+
+            foreach (array_filter($sourceEvent->select('VALARM'), [$this, 'isEmailAlarm']) as $alarm) {
+                $recipientAlarm = clone $alarm;
+                // Organizer aliases must not leak into an attendee's copied event.
+                foreach ($recipientAlarm->select('ATTENDEE') as $attendee) {
+                    if (strcasecmp($attendee->getNormalizedValue(), $message->recipient) !== 0) {
+                        $recipientAlarm->remove($attendee);
+                    }
+                }
+                if ($recipientAlarm->select('ATTENDEE')) {
+                    $vevent->add($recipientAlarm);
+                }
+            }
+        }
     }
 
     /**
@@ -327,6 +425,10 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
 
         if (PublicAgendaScheduleUtils::isPubliclyCreatedAndChairOrganizerNotAccepted($vCal)) {
             return;
+        }
+
+        if ($this->shouldEnableEmailValarmRecipientScheduling() && $this->ensureValarmUids($vCal)) {
+            $modified = true;
         }
 
         $addresses = $this->fetchCalendarOwnerAddresses($calendarPath);
@@ -385,12 +487,14 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
     }
 
     private function shouldEnforceRfc6638(): bool {
-        $value = getenv(self::ENFORCE_RFC_6638_ENV);
-        if ($value === false || trim($value) === '') {
-            return true;
-        }
+        return $this->envBoolean(self::ENFORCE_RFC_6638_ENV, true);
+    }
 
-        return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true;
+    private function envBoolean(string $name, bool $default): bool {
+        $value = getenv($name);
+        return $value === false || trim($value) === ''
+            ? $default
+            : filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? $default;
     }
 
     /**
@@ -459,7 +563,7 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
      *
      * As suggested by chibenwa in PR #142 review.
      */
-    protected function processICalendarChange($oldObject = null, VCalendar $newObject, array $addresses, array $ignore = [], &$modified = false) {
+    protected function processICalendarChange($oldObject, VCalendar $newObject, array $addresses, array $ignore = [], &$modified = false) {
         $messages = $this->createBroker()->parseEvent($newObject, $addresses, $oldObject);
 
         if ($messages) $modified = true;
@@ -485,7 +589,7 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
             // iTIP payload. Also strip RRULE from override VEVENTs (RFC 5545 §3.8.5.3 forbids
             // RRULE in a component that has RECURRENCE-ID; a misbehaving client may send it).
             if ($message->method === 'REQUEST') {
-                $this->sanitizeOutgoingRequestMessage($message);
+                $this->sanitizeOutgoingRequestMessage($message, $newObject);
             }
 
             $this->deliver($message);
@@ -611,7 +715,11 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
      * (RFC 5545 §3.8.5.3: RRULE MUST NOT appear in a component that has
      * RECURRENCE-ID; some clients send it anyway).
      */
-    private function sanitizeOutgoingRequestMessage(ITip\Message $message): void {
+    private function sanitizeOutgoingRequestMessage(ITip\Message $message, VCalendar $sourceCalendar): void {
+        if ($this->shouldEnableEmailValarmRecipientScheduling()) {
+            $this->filterEmailAlarmsForRecipient($message, $sourceCalendar);
+        }
+
         if (!CalendarObjectHelper::hasMasterEvent($message->message)) {
             // Override-only message: strip RRULE only (invalid per RFC 5545 §3.8.5.3
             // in a component that has RECURRENCE-ID), but KEEP RECURRENCE-ID.

--- a/run_test.sh
+++ b/run_test.sh
@@ -55,7 +55,7 @@ cleanup() {
 trap cleanup EXIT  # finally: sera exécuté *quoi qu'il arrive*
 
 javatest() {
-    git clone -b sabre-380 https://github.com/linagora/twake-calendar-integration-tests.git it-tests ||  exit 1
+    git clone https://github.com/linagora/twake-calendar-integration-tests.git it-tests ||  exit 1
     cd it-tests || exit 1
     bash pre-build.sh esn_sabre_test || exit 1
     mvn clean install -Dapi.version=1.43 -Dtest=com.linagora.dav.sabrev4_7.** -Damqp.scheduling.enabled=true || exit 1

--- a/run_test.sh
+++ b/run_test.sh
@@ -55,7 +55,7 @@ cleanup() {
 trap cleanup EXIT  # finally: sera exécuté *quoi qu'il arrive*
 
 javatest() {
-    git clone https://github.com/linagora/twake-calendar-integration-tests.git it-tests ||  exit 1
+    git clone -b testAlarm775 https://github.com/vttranlina/twake-calendar-integration-tests.git it-tests ||  exit 1
     cd it-tests || exit 1
     bash pre-build.sh esn_sabre_test || exit 1
     mvn clean install -Dapi.version=1.43 -Dtest=com.linagora.dav.sabrev4_7.** -Damqp.scheduling.enabled=true || exit 1

--- a/run_test.sh
+++ b/run_test.sh
@@ -55,7 +55,7 @@ cleanup() {
 trap cleanup EXIT  # finally: sera exécuté *quoi qu'il arrive*
 
 javatest() {
-    git clone -b testAlarm775 https://github.com/vttranlina/twake-calendar-integration-tests.git it-tests ||  exit 1
+    git clone https://github.com/linagora/twake-calendar-integration-tests.git it-tests ||  exit 1
     cd it-tests || exit 1
     bash pre-build.sh esn_sabre_test || exit 1
     mvn clean install -Dapi.version=1.43 -Dtest=com.linagora.dav.sabrev4_7.** -Damqp.scheduling.enabled=true || exit 1

--- a/tests/CalDAV/Schedule/SchedulePluginTest.php
+++ b/tests/CalDAV/Schedule/SchedulePluginTest.php
@@ -67,6 +67,18 @@ class SchedulePluginTest extends \PHPUnit\Framework\TestCase {
         $this->assertSame('', $message->recipient);
     }
 
+    function testShouldEnableEmailVALARMRecipientSchedulingByDefault() {
+        $this->withEmailValarmRecipientSchedulingEnv(null, function () {
+            $this->assertTrue($this->invokeShouldEnableEmailValarmRecipientScheduling());
+        });
+    }
+
+    function testShouldAllowDisablingEmailVALARMRecipientScheduling() {
+        $this->withEmailValarmRecipientSchedulingEnv('false', function () {
+            $this->assertFalse($this->invokeShouldEnableEmailValarmRecipientScheduling());
+        });
+    }
+
     function testShouldNotSkipMasterRequestWhenBrokerProjectsExdateForRecipientRemoval() {
         $oldObject = Reader::read(<<<'ICS'
 BEGIN:VCALENDAR
@@ -346,6 +358,157 @@ ICS
         $this->assertEquals('Local reminder', $newObject->VEVENT->VALARM->DESCRIPTION->getValue());
     }
 
+    function testShouldReplaceOrganizerManagedEmailVALARMAndPreservePersonalEmailVALARM() {
+        $this->withEmailValarmRecipientSchedulingEnv('true', function () {
+            $oldData = <<<'ICS'
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:event-email-alarm-merge
+DTSTART:20351005T090000Z
+DTEND:20351005T100000Z
+SUMMARY:Original meeting
+ORGANIZER:mailto:bob@example.org
+ATTENDEE:mailto:alice@example.org
+BEGIN:VALARM
+UID:organizer-reminder@example.org
+ACTION:EMAIL
+ATTENDEE:mailto:alice@example.org
+TRIGGER:-PT5M
+DESCRIPTION:Organizer reminder
+SUMMARY:Alarm notification
+END:VALARM
+BEGIN:VALARM
+UID:alice-personal-reminder@example.org
+ACTION:EMAIL
+ATTENDEE:mailto:alias@example.org
+TRIGGER:-PT10M
+DESCRIPTION:Personal reminder
+SUMMARY:Personal alarm notification
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+            $newObject = Reader::read(<<<'ICS'
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:event-email-alarm-merge
+DTSTART:20351005T090000Z
+DTEND:20351005T100000Z
+SUMMARY:Updated meeting
+ORGANIZER:mailto:bob@example.org
+ATTENDEE:mailto:alice@example.org
+BEGIN:VALARM
+UID:organizer-reminder@example.org
+ACTION:EMAIL
+ATTENDEE:mailto:alice@example.org
+TRIGGER:-PT20M
+DESCRIPTION:Organizer reminder
+SUMMARY:Alarm notification
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+ICS
+            );
+
+            $this->invokePreserveRecipientLocalProperties($oldData, $newObject);
+
+            $alarms = $newObject->VEVENT->select('VALARM');
+            $alarmsByUid = [];
+            foreach ($alarms as $alarm) {
+                $alarmsByUid[$alarm->UID->getValue()] = $alarm;
+            }
+
+            $this->assertCount(2, $alarms);
+            $this->assertEquals('-PT20M', $alarmsByUid['organizer-reminder@example.org']->TRIGGER->getValue());
+            $this->assertEquals('mailto:alice@example.org', $alarmsByUid['organizer-reminder@example.org']->ATTENDEE->getNormalizedValue());
+            $this->assertEquals('-PT10M', $alarmsByUid['alice-personal-reminder@example.org']->TRIGGER->getValue());
+            $this->assertEquals('mailto:alias@example.org', $alarmsByUid['alice-personal-reminder@example.org']->ATTENDEE->getNormalizedValue());
+        });
+    }
+
+    function testShouldRemoveOrganizerManagedEmailVALARMWhenNoLongerProjected() {
+        $this->withEmailValarmRecipientSchedulingEnv('true', function () {
+            $oldData = <<<'ICS'
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:event-email-alarm-removal
+DTSTART:20351005T090000Z
+DTEND:20351005T100000Z
+SUMMARY:Original meeting
+ORGANIZER:mailto:bob@example.org
+ATTENDEE:mailto:alice@example.org
+BEGIN:VALARM
+UID:organizer-reminder@example.org
+ACTION:EMAIL
+ATTENDEE:mailto:alice@example.org
+TRIGGER:-PT5M
+DESCRIPTION:Organizer reminder
+SUMMARY:Alarm notification
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+            $newObject = Reader::read(<<<'ICS'
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:event-email-alarm-removal
+DTSTART:20351005T090000Z
+DTEND:20351005T100000Z
+SUMMARY:Updated meeting
+ORGANIZER:mailto:bob@example.org
+ATTENDEE:mailto:alice@example.org
+END:VEVENT
+END:VCALENDAR
+ICS
+            );
+
+            $this->invokePreserveRecipientLocalProperties($oldData, $newObject);
+
+            $this->assertCount(0, $newObject->VEVENT->select('VALARM'));
+        });
+    }
+
+    function testShouldGenerateMissingVALARMUIDsAndPreserveExistingVALARMUIDs() {
+        $calendar = Reader::read(<<<'ICS'
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:event-valarm-uid
+DTSTART:20351005T090000Z
+DTEND:20351005T100000Z
+SUMMARY:Meeting with reminders
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER:-PT5M
+DESCRIPTION:Missing UID reminder
+END:VALARM
+BEGIN:VALARM
+UID:client-reminder
+ACTION:EMAIL
+ATTENDEE:mailto:alice@example.org
+TRIGGER:-PT10M
+DESCRIPTION:Client UID reminder
+SUMMARY:Alarm notification
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+ICS
+        );
+
+        $modified = $this->invokeEnsureValarmUids($calendar);
+
+        $alarms = $calendar->VEVENT->select('VALARM');
+        $this->assertTrue($modified);
+        $this->assertMatchesRegularExpression('/^alarm-[0-9a-fA-F-]{36}$/', $alarms[0]->UID->getValue());
+        $this->assertEquals('client-reminder', $alarms[1]->UID->getValue());
+    }
+
     function testShouldRejectForbiddenAttendeeSchedulingObjectChanges() {
         $forbiddenChanges = [
             'DTSTART' => [
@@ -493,6 +656,120 @@ ICS
 
         $this->assertEquals('TRANSPARENT', $newObject->VEVENT->TRANSP->getValue());
         $this->assertEquals('-PT5M', $newObject->VEVENT->VALARM->TRIGGER->getValue());
+        $this->assertEquals('Local reminder', $newObject->VEVENT->VALARM->DESCRIPTION->getValue());
+    }
+
+    function testShouldAllowAttendeePersonalEmailVALARMWithAlias() {
+        $oldObject = Reader::read(<<<'ICS'
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:event-allowed-attendee-personal-email-alarm
+DTSTART:20351005T090000Z
+DTEND:20351005T100000Z
+SUMMARY:Original meeting
+LOCATION:Room A
+ORGANIZER:mailto:bob@example.org
+ATTENDEE:mailto:alice@example.org
+END:VEVENT
+END:VCALENDAR
+ICS
+        );
+        $newObject = Reader::read(<<<'ICS'
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:event-allowed-attendee-personal-email-alarm
+DTSTART:20351005T090000Z
+DTEND:20351005T100000Z
+SUMMARY:Original meeting
+LOCATION:Room A
+ORGANIZER:mailto:bob@example.org
+ATTENDEE:mailto:alice@example.org
+BEGIN:VALARM
+ACTION:EMAIL
+ATTENDEE:mailto:alias@example.org
+TRIGGER:-PT5M
+DESCRIPTION:Local reminder
+SUMMARY:Alarm notification
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+ICS
+        );
+
+        $this->invokeAssertAllowedAttendeeSchedulingObjectChange($oldObject, $newObject, ['mailto:alice@example.org']);
+
+        $this->assertEquals('-PT5M', $newObject->VEVENT->VALARM->TRIGGER->getValue());
+        $this->assertEquals('mailto:alias@example.org', $newObject->VEVENT->VALARM->ATTENDEE->getNormalizedValue());
+    }
+
+    function testShouldFilterEmailVALARMsByRequestRecipient() {
+        $this->withEmailValarmRecipientSchedulingEnv('true', function () {
+            // Given an outgoing request with recipient-specific email alarms and a display alarm
+            $sourceCalendar = Reader::read(<<<'ICS'
+BEGIN:VCALENDAR
+VERSION:2.0
+METHOD:REQUEST
+BEGIN:VEVENT
+UID:event-recipient-specific-alarms
+DTSTART:20351005T090000Z
+DTEND:20351005T100000Z
+ORGANIZER:mailto:bob@example.org
+ATTENDEE:mailto:alice@example.org
+ATTENDEE:mailto:bob@example.org
+BEGIN:VALARM
+ACTION:EMAIL
+ATTENDEE:MAILTO:ALICE@EXAMPLE.ORG
+ATTENDEE:mailto:alias@example.org
+TRIGGER:-PT10M
+DESCRIPTION:Alice reminder
+SUMMARY:Alarm notification
+END:VALARM
+BEGIN:VALARM
+ACTION:EMAIL
+ATTENDEE:mailto:bob@example.org
+TRIGGER:-PT5M
+DESCRIPTION:Bob reminder
+SUMMARY:Alarm notification
+END:VALARM
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER:-PT15M
+DESCRIPTION:Display reminder
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+ICS
+            );
+            $message = new Message();
+            $message->recipient = 'mailto:alice@example.org';
+            $message->message = clone $sourceCalendar;
+            $message->message->VEVENT->select('VALARM')[1]->ATTENDEE = 'mailto:alice@example.org';
+
+            // When the broker-rewritten request is sanitized for Alice from the organizer source
+            $this->invokeSanitizeOutgoingRequestMessage($message, $sourceCalendar);
+
+            // Then Alice's email alarm and the non-email alarm remain, while Bob's email alarm is removed
+            $alarms = $message->message->VEVENT->select('VALARM');
+            $this->assertCount(2, $alarms);
+            $this->assertEqualsCanonicalizing(['-PT10M', '-PT15M'], array_values(array_map(
+                fn ($alarm) => $alarm->TRIGGER->getValue(),
+                $alarms
+            )));
+            $emailAlarms = array_values(array_filter(
+                $alarms,
+                fn ($alarm) => isset($alarm->ACTION) && strcasecmp($alarm->ACTION->getValue(), 'EMAIL') === 0
+            ));
+            $this->assertCount(1, $emailAlarms);
+            $this->assertSame(
+                ['mailto:alice@example.org'],
+                array_values(array_map(
+                    fn ($attendee) => $attendee->getNormalizedValue(),
+                    $emailAlarms[0]->select('ATTENDEE')
+                ))
+            );
+        });
     }
 
     function testForbiddenAttendeeSchedulingObjectChangeShouldSerializeCalDAVPrecondition() {
@@ -580,6 +857,27 @@ END:VCALENDAR
         $method->invoke($this->plugin, $oldICalendarData, $newObject);
     }
 
+    private function invokeSanitizeOutgoingRequestMessage(Message $message, $sourceCalendar): void {
+        $method = new \ReflectionMethod(Plugin::class, 'sanitizeOutgoingRequestMessage');
+        $method->setAccessible(true);
+
+        $method->invoke($this->plugin, $message, $sourceCalendar);
+    }
+
+    private function invokeEnsureValarmUids($calendarObject): bool {
+        $method = new \ReflectionMethod(Plugin::class, 'ensureValarmUids');
+        $method->setAccessible(true);
+
+        return $method->invoke($this->plugin, $calendarObject);
+    }
+
+    private function invokeShouldEnableEmailValarmRecipientScheduling(): bool {
+        $method = new \ReflectionMethod(Plugin::class, 'shouldEnableEmailValarmRecipientScheduling');
+        $method->setAccessible(true);
+
+        return $method->invoke($this->plugin);
+    }
+
     private function invokeAssertAllowedAttendeeSchedulingObjectChange($oldObject, $newObject, array $addresses) {
         $method = new \ReflectionMethod(Plugin::class, 'assertAllowedAttendeeSchedulingObjectChange');
         $method->setAccessible(true);
@@ -603,6 +901,26 @@ END:VCALENDAR
                 putenv('SABRE_ENFORCE_RFC_6638');
             } else {
                 putenv('SABRE_ENFORCE_RFC_6638=' . $previousValue);
+            }
+        }
+    }
+
+    private function withEmailValarmRecipientSchedulingEnv(?string $value, callable $callback) {
+        $previousValue = getenv('SABRE_EMAIL_VALARM_RECIPIENT_SCHEDULING');
+
+        try {
+            if ($value === null) {
+                putenv('SABRE_EMAIL_VALARM_RECIPIENT_SCHEDULING');
+            } else {
+                putenv('SABRE_EMAIL_VALARM_RECIPIENT_SCHEDULING=' . $value);
+            }
+
+            return $callback();
+        } finally {
+            if ($previousValue === false) {
+                putenv('SABRE_EMAIL_VALARM_RECIPIENT_SCHEDULING');
+            } else {
+                putenv('SABRE_EMAIL_VALARM_RECIPIENT_SCHEDULING=' . $previousValue);
             }
         }
     }


### PR DESCRIPTION
Ref: https://github.com/linagora/twake-calendar-side-service/issues/775


In addition to what has already been discussed in [775](https://github.com/linagora/twake-calendar-side-service/issues/775), 
I would like to propose an additional mechanism: assigning a `UID` to each `VALARM`.

This concept is defined in [[RFC 9074, Section 4](https://www.rfc-editor.org/rfc/rfc9074.html#section-4)](https://www.rfc-editor.org/rfc/rfc9074.html#section-4), which introduces a unique identifier for `VALARM` components.

A stable UID would allow the system to distinguish between:

- Organizer-managed alarms propagated to an attendee’s event copy.
- Personal alarms created locally by the attendee.

This distinction would make the merge logic more reliable when the organizer later updates