### PR TITLE
Require DTSTART for RRULE/EXDATE and document strict TZID matching

### DIFF
--- a/lib/CalDAV/Validation/CalendarObjectValidator.php
+++ b/lib/CalDAV/Validation/CalendarObjectValidator.php
@@ -16,8 +16,15 @@ class CalendarObjectValidator {
     private function validateRRules(VCalendar $vCalendar): void
     {
         foreach ($vCalendar->select('VEVENT') as $vevent) {
-            if (!isset($vevent->RRULE) || !isset($vevent->DTSTART)) {
+            if (!isset($vevent->RRULE)) {
                 continue;
+            }
+
+            // RFC 5545 §3.6.1: a VEVENT carrying RRULE MUST also carry DTSTART
+            // (the recurrence set is computed from it). Reject explicitly rather
+            // than silently skipping and relying on upstream Sabre validation.
+            if (!isset($vevent->DTSTART)) {
+                $this->fail('VEVENT with RRULE MUST have a DTSTART property');
             }
 
             foreach ($vevent->select('RRULE') as $rrule) {
@@ -100,8 +107,15 @@ class CalendarObjectValidator {
     private function validateExDates(VCalendar $vCalendar): void
     {
         foreach ($vCalendar->select('VEVENT') as $vevent) {
-            if (!isset($vevent->EXDATE) || !isset($vevent->DTSTART)) {
+            if (!isset($vevent->EXDATE)) {
                 continue;
+            }
+
+            // EXDATE only has meaning relative to the recurrence set anchored on
+            // DTSTART. A VEVENT with EXDATE but no DTSTART is invalid (RFC 5545
+            // §3.6.1); reject it explicitly rather than silently skipping.
+            if (!isset($vevent->DTSTART)) {
+                $this->fail('VEVENT with EXDATE MUST have a DTSTART property');
             }
 
             foreach ($vevent->select('EXDATE') as $exDate) {
@@ -180,6 +194,16 @@ class CalendarObjectValidator {
 
     private function assertSameDateTimeForm(DateTimeProperty $property, DateTimeProperty $dtStart): void
     {
+        // INTENTIONALLY STRICTER THAN RFC 5545: for RECURRENCE-ID and EXDATE the
+        // RFC only requires the same *value type* as DTSTART, so two different but
+        // valid zones (e.g. DTSTART TZID=Europe/Paris and EXDATE TZID=Europe/Berlin,
+        // or a UTC override of a TZID master) are technically legal. We deliberately
+        // require the exact same date-time form (identical TZID, UTC, or FLOATING)
+        // because the regressions this validator guards against (see #1089) produce
+        // a RECURRENCE-ID/EXDATE in the wrong timezone form while keeping a valid
+        // value type. This can reject interoperable third-party clients that legally
+        // use a different-but-equivalent zone; that trade-off is accepted to protect
+        // first-party (Twake) traffic.
         $dtStartValue = DateLikeValue::fromProperty($dtStart);
         foreach ($property->getParts() as $value) {
             $propertyValue = DateLikeValue::fromProperty($property, $value);

--- a/tests/CalDAV/Validation/CalendarObjectValidatorTest.php
+++ b/tests/CalDAV/Validation/CalendarObjectValidatorTest.php
@@ -377,6 +377,38 @@ class CalendarObjectValidatorTest extends TestCase {
         ]);
     }
 
+    function testRRuleWithoutDtStartIsRejected() {
+        $this->assertValidationFails([
+            'BEGIN:VCALENDAR',
+            'VERSION:2.0',
+            'PRODID:-//test//EN',
+            'BEGIN:VEVENT',
+            'UID:event-1',
+            'DTSTAMP:20260515T000000Z',
+            'RRULE:FREQ=DAILY;COUNT=3',
+            'END:VEVENT',
+            'END:VCALENDAR'
+        ], [
+            'VEVENT with RRULE MUST have a DTSTART property'
+        ]);
+    }
+
+    function testExDateWithoutDtStartIsRejected() {
+        $this->assertValidationFails([
+            'BEGIN:VCALENDAR',
+            'VERSION:2.0',
+            'PRODID:-//test//EN',
+            'BEGIN:VEVENT',
+            'UID:event-1',
+            'DTSTAMP:20260515T000000Z',
+            'EXDATE:20260516T090000Z',
+            'END:VEVENT',
+            'END:VCALENDAR'
+        ], [
+            'VEVENT with EXDATE MUST have a DTSTART property'
+        ]);
+    }
+
     function testDateExDateWithDateTimeDtStartIsRejected() {
         $this->assertValidationFails([
             'BEGIN:VCALENDAR',


### PR DESCRIPTION
Closes #398

Addresses points 4 and 6 of the `CalendarObjectValidator` review.

### Point 6 — reject RRULE/EXDATE without DTSTART

A VEVENT carrying `RRULE` or `EXDATE` but no `DTSTART` was silently skipped (`!isset($vevent->DTSTART) → continue`), leaving this validator dependent on upstream Sabre validation. Such a VEVENT is invalid per RFC 5545 §3.6.1 (the recurrence set is computed from `DTSTART`). The validator now rejects it explicitly:

- `VEVENT with RRULE MUST have a DTSTART property`
- `VEVENT with EXDATE MUST have a DTSTART property`

### Point 4 — document the deliberate stricter-than-RFC TZID matching

For `RECURRENCE-ID`/`EXDATE`, RFC 5545 only requires the *same value type* as `DTSTART`, so a different-but-equivalent zone (e.g. `Europe/Paris` vs `Europe/Berlin`) is technically legal. This validator deliberately requires the exact same date-time form to catch the regression class from linagora/twake-calendar-frontend#1089 (wrong zone, valid value type). An explicit code comment now documents this as an intentional trade-off that protects first-party (Twake) traffic at the cost of possibly rejecting some interoperable third-party clients.

### Tests

Added `testRRuleWithoutDtStartIsRejected` and `testExDateWithoutDtStartIsRejected`.

> Note: PHP/PHPUnit are not runnable in my sandbox (the test harness is Docker-based); the new test cases follow the existing `assertValidationFails` pattern.
