### PR TITLE
fix(caldav): register custom VObject property types

### DIFF
--- a/lib/CalDAV/NullableUri.php
+++ b/lib/CalDAV/NullableUri.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace ESN\CalDAV;
+
+use Sabre\VObject\Component\VCalendar;
+use Sabre\VObject\Property\Uri;
+
+class NullableUri extends Uri
+{
+    #[\ReturnTypeWillChange]
+    public function offsetSet($name, $value)
+    {
+        if (!$this->isNullableProperty()
+            && strtoupper((string)$name) === 'VALUE'
+            && strtoupper((string)$value) === 'URI'
+            && !isset($this->parameters['VALUE'])) {
+            return;
+        }
+
+        parent::offsetSet($name, $value);
+    }
+
+    public function setJsonValue(array $value)
+    {
+        parent::setJsonValue($this->isNullableProperty() && [null] === $value ? [''] : $value);
+    }
+
+    private function isNullableProperty(): bool
+    {
+        return (VCalendar::$propertyMap[$this->name] ?? null) === self::class;
+    }
+}

--- a/lib/CalDAV/Plugin.php
+++ b/lib/CalDAV/Plugin.php
@@ -26,6 +26,8 @@ class Plugin extends \Sabre\CalDAV\Plugin {
     }
 
     function initialize(Server $server) {
+        VObjectPropertyRegistry::register();
+
         parent::initialize($server);
         $server->on('calendarObjectChange', [$this, 'validateCalendarObjectBeforeScheduling'], self::PRIORITY_BEFORE_SCHEDULING);
         $server->on('propFind', [$this, 'propFindSharedCalendar'], 151);

--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -2,11 +2,13 @@
 namespace ESN\CalDAV\Schedule;
 
 use ESN\CalDAV\Schedule\Exception\ForbiddenAttendeeSchedulingObjectChange;
+use ESN\CalDAV\VObjectPropertyRegistry;
 use ESN\Utils\Utils;
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
 use Sabre\CalDAV\ICalendarObject;
 use Sabre\CalDAV\Schedule\ISchedulingObject;
+use Sabre\DAV\Server;
 use
     Sabre\HTTP\RequestInterface,
     Sabre\HTTP\ResponseInterface,
@@ -43,6 +45,11 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
         $this->logger = new Logger('esn-sabre');
         $this->logger->pushHandler(new StreamHandler('php://stderr', Logger::DEBUG));
         $this->principalBackend = $principalBackend;
+    }
+
+    function initialize(Server $server) {
+        VObjectPropertyRegistry::register();
+        parent::initialize($server);
     }
 
     protected function scheduleReply(RequestInterface $request) {

--- a/lib/CalDAV/VObjectPropertyRegistry.php
+++ b/lib/CalDAV/VObjectPropertyRegistry.php
@@ -1,0 +1,23 @@
+<?php
+namespace ESN\CalDAV;
+
+use Sabre\VObject\Component\VCalendar;
+use Sabre\VObject\Property\Boolean;
+use Sabre\VObject\Property\Text;
+use Sabre\VObject\Property\Uri;
+
+class VObjectPropertyRegistry {
+    // Register extension properties here so VObject parses them with the right value class.
+    const array ICALENDAR_PROPERTY_TYPES = [
+        'X-PUBLICLY-CREATED' => Boolean::class,
+        'X-PUBLICLY-CREATOR' => Text::class,
+        'X-OPENPAAS-BOOKING-LINK' => Text::class,
+        'X-OPENPAAS-VIDEOCONFERENCE' => Uri::class,
+    ];
+
+    public static function register(): void {
+        foreach (self::ICALENDAR_PROPERTY_TYPES as $propertyName => $propertyClass) {
+            VCalendar::$propertyMap[$propertyName] = $propertyClass;
+        }
+    }
+}

--- a/lib/CalDAV/VObjectPropertyRegistry.php
+++ b/lib/CalDAV/VObjectPropertyRegistry.php
@@ -12,12 +12,20 @@ class VObjectPropertyRegistry {
         'X-PUBLICLY-CREATED' => Boolean::class,
         'X-PUBLICLY-CREATOR' => Text::class,
         'X-OPENPAAS-BOOKING-LINK' => Text::class,
-        'X-OPENPAAS-VIDEOCONFERENCE' => Uri::class,
+        'X-OPENPAAS-VIDEOCONFERENCE' => NullableUri::class,
+    ];
+
+    const array ICALENDAR_VALUE_TYPES = [
+        'URI' => NullableUri::class,
     ];
 
     public static function register(): void {
         foreach (self::ICALENDAR_PROPERTY_TYPES as $propertyName => $propertyClass) {
             VCalendar::$propertyMap[$propertyName] = $propertyClass;
+        }
+
+        foreach (self::ICALENDAR_VALUE_TYPES as $valueType => $propertyClass) {
+            VCalendar::$valueMap[$valueType] = $propertyClass;
         }
     }
 }

--- a/lib/JSON/Plugin.php
+++ b/lib/JSON/Plugin.php
@@ -2,6 +2,7 @@
 
 namespace ESN\JSON;
 
+use ESN\CalDAV\VObjectPropertyRegistry;
 use ESN\JSON\CalDAV\CalendarHandler;
 use ESN\JSON\CalDAV\CalendarObjectHandler;
 use ESN\JSON\CalDAV\SubscriptionHandler;
@@ -40,6 +41,8 @@ class Plugin extends \Sabre\CalDAV\Plugin {
     }
 
     function initialize(DAV\Server $server) {
+        VObjectPropertyRegistry::register();
+
         $this->server = $server;
         $server->on('beforeMethod:*', [$this, 'beforeMethod'], 15); // 15 is after Auth and before ACL
         $server->on('beforeWriteContent', [$this, 'beforeWriteContent']);

--- a/run_test.sh
+++ b/run_test.sh
@@ -55,7 +55,7 @@ cleanup() {
 trap cleanup EXIT  # finally: sera exécuté *quoi qu'il arrive*
 
 javatest() {
-    git clone -b test/expect-videoconference-uri-type https://github.com/vttranlina/twake-calendar-integration-tests.git it-tests ||  exit 1
+    git clone https://github.com/linagora/twake-calendar-integration-tests.git it-tests ||  exit 1
     cd it-tests || exit 1
     bash pre-build.sh esn_sabre_test || exit 1
     mvn clean install -Dapi.version=1.43 -Dtest=com.linagora.dav.sabrev4_7.** -Damqp.scheduling.enabled=true || exit 1

--- a/run_test.sh
+++ b/run_test.sh
@@ -55,7 +55,7 @@ cleanup() {
 trap cleanup EXIT  # finally: sera exécuté *quoi qu'il arrive*
 
 javatest() {
-    git clone https://github.com/linagora/twake-calendar-integration-tests.git it-tests ||  exit 1
+    git clone -b test/expect-videoconference-uri-type https://github.com/vttranlina/twake-calendar-integration-tests.git it-tests ||  exit 1
     cd it-tests || exit 1
     bash pre-build.sh esn_sabre_test || exit 1
     mvn clean install -Dapi.version=1.43 -Dtest=com.linagora.dav.sabrev4_7.** -Damqp.scheduling.enabled=true || exit 1

--- a/tests/CalDAV/Schedule/SchedulePluginTest.php
+++ b/tests/CalDAV/Schedule/SchedulePluginTest.php
@@ -50,6 +50,14 @@ class SchedulePluginTest extends \PHPUnit\Framework\TestCase {
         $this->assertTrue($shouldSkip);
     }
 
+    function testShouldDetectPubliclyCreatedWithExplicitBooleanValueType() {
+        $vcalendar = Reader::read($this->newCalendarWithOrganizerChairPartstat('NEEDS-ACTION', 'VALUE=BOOLEAN:TRUE'));
+
+        $shouldSkip = PublicAgendaScheduleUtils::isPubliclyCreatedAndChairOrganizerNotAccepted($vcalendar);
+
+        $this->assertTrue($shouldSkip);
+    }
+
     function testShouldNotSkipWhenChairOrganizerAcceptedEvenIfPubliclyCreated() {
         $vcalendar = Reader::read($this->newCalendarWithOrganizerChairPartstat('ACCEPTED', true));
 
@@ -818,7 +826,9 @@ END:VCALENDAR
     }
 
     private function newCalendarWithOrganizerChairPartstat($partstat, $publiclyCreated) {
-        $publiclyCreatedValue = $publiclyCreated ? 'true' : 'false';
+        $publiclyCreatedProperty = is_bool($publiclyCreated)
+            ? 'X-PUBLICLY-CREATED:' . ($publiclyCreated ? 'true' : 'false')
+            : 'X-PUBLICLY-CREATED;' . $publiclyCreated;
 
         return "BEGIN:VCALENDAR
 VERSION:2.0
@@ -827,7 +837,7 @@ UID:test-publicly-created
 DTSTART:20260227T000000Z
 DTEND:20260227T003000Z
 SUMMARY:Test event
-X-PUBLICLY-CREATED:$publiclyCreatedValue
+$publiclyCreatedProperty
 ORGANIZER:mailto:alice@example.org
 ATTENDEE;PARTSTAT=$partstat;ROLE=CHAIR:mailto:alice@example.org
 ATTENDEE;PARTSTAT=NEEDS-ACTION;ROLE=REQ-PARTICIPANT:mailto:bob@example.org

--- a/tests/JSON/PluginTest.php
+++ b/tests/JSON/PluginTest.php
@@ -44,6 +44,114 @@ class PluginTest extends \ESN\DAV\ServerMock {
         $this->assertCount(1, $jsonResponse->_embedded->{'dav:item'});
     }
 
+    function testTimeRangeQuerySerializesRegisteredCustomCalendarPropertiesWithConfiguredTypes() {
+        $customEvent = 'BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:custom-property-event
+DTSTART:20120227T010000Z
+DTEND:20120227T020000Z
+SUMMARY:Custom property event
+X-OPENPAAS-VIDEOCONFERENCE:https://meet.example/room
+X-PUBLICLY-CREATED:true
+X-PUBLICLY-CREATOR:bob@linagora.local
+X-OPENPAAS-BOOKING-LINK:booking-link-id
+END:VEVENT
+END:VCALENDAR
+';
+        $this->caldavBackend->createCalendarObject($this->cal['id'], 'custom-property.ics', $customEvent);
+
+        $request = \Sabre\HTTP\Sapi::createFromServerArray(array(
+            'REQUEST_METHOD'    => 'REPORT',
+            'HTTP_CONTENT_TYPE' => 'application/json',
+            'HTTP_ACCEPT'       => 'application/json',
+            'REQUEST_URI'       => '/calendars/54b64eadf6d7d8e41d263e0f/calendar1.json',
+        ));
+
+        $request->setBody(json_encode($this->timeRangeData));
+        $response = $this->request($request);
+        $jsonResponse = json_decode($response->getBodyAsString(), true);
+
+        $customItem = null;
+        foreach ($jsonResponse['_embedded']['dav:item'] as $item) {
+            if (str_contains($item['_links']['self']['href'], 'custom-property.ics')) {
+                $customItem = $item;
+                break;
+            }
+        }
+
+        $this->assertNotNull($customItem);
+        $veventProperties = $customItem['data'][2][0][1];
+
+        $videoConference = $this->findJCalProperty($veventProperties, 'x-openpaas-videoconference');
+        $publiclyCreated = $this->findJCalProperty($veventProperties, 'x-publicly-created');
+        $publiclyCreator = $this->findJCalProperty($veventProperties, 'x-publicly-creator');
+        $bookingLink = $this->findJCalProperty($veventProperties, 'x-openpaas-booking-link');
+
+        $this->assertEquals('uri', $videoConference[2]);
+        $this->assertEquals('https://meet.example/room', $videoConference[3]);
+        $this->assertEquals('boolean', $publiclyCreated[2]);
+        $this->assertTrue($publiclyCreated[3]);
+        $this->assertEquals('text', $publiclyCreator[2]);
+        $this->assertEquals('bob@linagora.local', $publiclyCreator[3]);
+        $this->assertEquals('text', $bookingLink[2]);
+        $this->assertEquals('booking-link-id', $bookingLink[3]);
+    }
+
+    function testCalendarObjectReportSerializesRegisteredCustomCalendarPropertiesWithConfiguredTypes() {
+        $customEvent = 'BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:custom-property-object-event
+DTSTART:20120227T010000Z
+DTEND:20120227T020000Z
+SUMMARY:Custom property object event
+X-OPENPAAS-VIDEOCONFERENCE:https://meet.example/room
+X-PUBLICLY-CREATED:true
+X-PUBLICLY-CREATOR:bob@linagora.local
+X-OPENPAAS-BOOKING-LINK:booking-link-id
+END:VEVENT
+END:VCALENDAR
+';
+        $this->caldavBackend->createCalendarObject($this->cal['id'], 'custom-property-object.ics', $customEvent);
+
+        $request = \Sabre\HTTP\Sapi::createFromServerArray(array(
+            'REQUEST_METHOD'    => 'REPORT',
+            'HTTP_CONTENT_TYPE' => 'application/json',
+            'HTTP_ACCEPT'       => 'application/json',
+            'REQUEST_URI'       => '/calendars/54b64eadf6d7d8e41d263e0f/calendar1/custom-property-object.ics',
+        ));
+
+        $request->setBody(json_encode($this->timeRangeData));
+        $response = $this->request($request);
+        $jsonResponse = json_decode($response->getBodyAsString(), true);
+        $veventProperties = $jsonResponse['data'][2][0][1];
+
+        $videoConference = $this->findJCalProperty($veventProperties, 'x-openpaas-videoconference');
+        $publiclyCreated = $this->findJCalProperty($veventProperties, 'x-publicly-created');
+        $publiclyCreator = $this->findJCalProperty($veventProperties, 'x-publicly-creator');
+        $bookingLink = $this->findJCalProperty($veventProperties, 'x-openpaas-booking-link');
+
+        $this->assertEquals('uri', $videoConference[2]);
+        $this->assertEquals('https://meet.example/room', $videoConference[3]);
+        $this->assertEquals('boolean', $publiclyCreated[2]);
+        $this->assertTrue($publiclyCreated[3]);
+        $this->assertEquals('text', $publiclyCreator[2]);
+        $this->assertEquals('bob@linagora.local', $publiclyCreator[3]);
+        $this->assertEquals('text', $bookingLink[2]);
+        $this->assertEquals('booking-link-id', $bookingLink[3]);
+    }
+
+    private function findJCalProperty($properties, $propertyName) {
+        foreach ($properties as $property) {
+            if ($property[0] === $propertyName) {
+                return $property;
+            }
+        }
+
+        return null;
+    }
+
     function testTimeRangeQueryShouldReturnTwoEventsWhenBothAreInRange() {
         $request = \Sabre\HTTP\Sapi::createFromServerArray(array(
             'REQUEST_METHOD'    => 'REPORT',


### PR DESCRIPTION
```
   const array ICALENDAR_PROPERTY_TYPES = [
        'X-PUBLICLY-CREATED' => Boolean::class,
        'X-PUBLICLY-CREATOR' => Text::class,
        'X-OPENPAAS-BOOKING-LINK' => Text::class,
        'X-OPENPAAS-VIDEOCONFERENCE' => Uri::class,
    ];
```


This PR fixes an issue where jCal responses returned by client `REPORT` requests serialized our intentional custom properties with the `unknown` value type.

```json
["x-openpaas-videoconference", {}, "unknown", "..."]
```

This does not introduce a breaking behavior change. It only makes custom property type declarations stronger and more explicit, aligned with RFC expectations