### PR TITLE
Simple reports efficiency: batch calendar-query REPORT (#403)

### DIFF
--- a/lib/CalDAV/Backend/Service/CalendarObjectService.php
+++ b/lib/CalDAV/Backend/Service/CalendarObjectService.php
@@ -347,7 +347,7 @@ class CalendarObjectService {
      */
     private function buildProjection($requirePostFilter, $returnFullData) {
         if ($returnFullData) {
-            return ['uri' => 1, 'calendardata' => 1, 'etag' => 1];
+            return ['uri' => 1, 'calendardata' => 1, 'etag' => 1, 'classification' => 1];
         }
 
         if ($requirePostFilter) {
@@ -383,6 +383,7 @@ class CalendarObjectService {
                 'uri' => $row['uri'],
                 'calendardata' => $row['calendardata'],
                 'etag' => '"' . $row['etag'] . '"',
+                'classification' => isset($row['classification']) ? $row['classification'] : null,
                 'vObject' => $vObject
             ];
         }

--- a/lib/CalDAV/Plugin.php
+++ b/lib/CalDAV/Plugin.php
@@ -166,6 +166,10 @@ class Plugin extends \Sabre\CalDAV\Plugin {
      * @return array
      */
     protected function buildCalendarQueryReportResult($report, $path, ICalendarObjectContainer $node, $needsJson, $calendarTimeZone) {
+        if ($this->canReportFromSingleQuery($report, $node)) {
+            return $this->buildCalendarQueryReportResultFromSingleQuery($report, $path, $node, $needsJson);
+        }
+
         $calendarDataProp = '{' . self::NS_CALDAV . '}calendar-data';
 
         $nodePaths = $node->calendarQuery($report->filters);
@@ -198,6 +202,144 @@ class Plugin extends \Sabre\CalDAV\Plugin {
         }
 
         return $result;
+    }
+
+    /**
+     * Whether the calendar-query REPORT can be answered straight from a single
+     * Mongo query (uri + calendardata + etag) without going through
+     * getPropertiesForMultiplePaths at all.
+     *
+     * This is the common filter-less case (the reindex REPORT): the objects are
+     * already returned with their data by the query, so we skip the extra node
+     * resolution round-trip entirely and parse each object at most once.
+     *
+     * We stay conservative: anything with a real filter, an expand, a non-Mongo
+     * backend, or a requested property we cannot synthesise from the query
+     * result falls back to the standard (batched) path.
+     *
+     * @param \Sabre\CalDAV\Xml\Request\CalendarQueryReport $report
+     * @param ICalendarObjectContainer $node
+     * @return bool
+     */
+    private function canReportFromSingleQuery($report, ICalendarObjectContainer $node) {
+        if ($report->expand) {
+            return false;
+        }
+
+        if (!($node instanceof SharedCalendar) || !($node->getBackend() instanceof Backend\Mongo)) {
+            return false;
+        }
+
+        $filters = $report->filters;
+        if (!empty($filters['prop-filters']) || !empty($filters['comp-filters'])) {
+            return false;
+        }
+
+        if (empty($report->properties)) {
+            return false;
+        }
+
+        $servable = ['{DAV:}getetag', '{' . self::NS_CALDAV . '}calendar-data'];
+        foreach ($report->properties as $property) {
+            if (!in_array($property, $servable, true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Builds the multistatus entries for a filter-less calendar-query REPORT
+     * directly from calendarQueryWithAllData(), i.e. a single query returning
+     * uri + calendardata + etag for every object.
+     *
+     * @param \Sabre\CalDAV\Xml\Request\CalendarQueryReport $report
+     * @param string $path
+     * @param SharedCalendar $node
+     * @param bool $needsJson
+     * @return array
+     */
+    private function buildCalendarQueryReportResultFromSingleQuery($report, $path, SharedCalendar $node, $needsJson) {
+        $calendarDataProp = '{' . self::NS_CALDAV . '}calendar-data';
+        $etagProp = '{DAV:}getetag';
+
+        $wantsCalendarData = in_array($calendarDataProp, $report->properties, true);
+        $wantsEtag = in_array($etagProp, $report->properties, true);
+
+        $currentUser = $this->getCurrentUserPrincipal();
+        $calendarOwner = $node->getOwner();
+        // Same rule as PrivateEventPlugin: a delegate (not the calendar owner)
+        // only sees a sanitized version of PRIVATE / CONFIDENTIAL events.
+        $sanitizeForDelegate = $currentUser !== null && $calendarOwner !== null && $calendarOwner !== $currentUser;
+
+        $result = [];
+        foreach ($node->getBackend()->calendarQueryWithAllData($node->getFullCalendarId(), $report->filters) as $object) {
+            $properties = [];
+
+            if ($wantsCalendarData) {
+                $properties[$calendarDataProp] = $this->renderCalendarData($object, $node, $currentUser, $sanitizeForDelegate, $needsJson);
+            }
+            if ($wantsEtag) {
+                $properties[$etagProp] = $object['etag'];
+            }
+
+            $result[] = [
+                200 => $properties,
+                404 => [],
+                'href' => $path . '/' . $object['uri']
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Renders the calendar-data of a single query result, applying the same
+     * private-event sanitization PrivateEventPlugin would apply on the standard
+     * propFind path. Non-private objects are returned verbatim without being
+     * parsed, so their serialization is byte-for-byte identical to the standard
+     * path.
+     *
+     * @param array $object Query result with uri/calendardata/etag/classification
+     * @param SharedCalendar $node
+     * @param string|null $currentUser
+     * @param bool $sanitizeForDelegate
+     * @param bool $needsJson
+     * @return string
+     */
+    private function renderCalendarData($object, SharedCalendar $node, $currentUser, $sanitizeForDelegate, $needsJson) {
+        $classification = isset($object['classification']) ? strtoupper($object['classification']) : null;
+        $needsSanitization = $sanitizeForDelegate
+            && ($classification === 'PRIVATE' || $classification === 'CONFIDENTIAL');
+
+        if (!$needsJson && !$needsSanitization) {
+            return $object['calendardata'];
+        }
+
+        $vObject = isset($object['vObject']) && $object['vObject'] !== null
+            ? $object['vObject']
+            : Reader::read($object['calendardata']);
+
+        $rendered = $vObject;
+        if ($needsSanitization) {
+            $rendered = \ESN\Utils\Utils::hidePrivateEventInfoForUser($vObject, $node, $currentUser);
+        }
+
+        $data = $needsJson ? json_encode($rendered->jsonSerialize()) : $rendered->serialize();
+
+        if ($rendered !== $vObject) {
+            $rendered->destroy();
+        }
+        $vObject->destroy();
+
+        return $data;
+    }
+
+    private function getCurrentUserPrincipal() {
+        $authPlugin = $this->server->getPlugin('auth');
+
+        return $authPlugin ? $authPlugin->getCurrentPrincipal() : null;
     }
 
 }

--- a/lib/CalDAV/Plugin.php
+++ b/lib/CalDAV/Plugin.php
@@ -1,10 +1,8 @@
 <?php
 namespace ESN\CalDAV;
 
-use DateTimeZone;
 use ESN\CalDAV\Validation\CalendarObjectValidator;
 use ESN\DAV\Sharing\Plugin as SPlugin;
-use Sabre\CalDAV\ICalendarObjectContainer;
 use Sabre\DAV\Exception\BadRequest;
 use Sabre\DAV\Exception\UnsupportedMediaType;
 use Sabre\DAV\INode;
@@ -14,7 +12,6 @@ use Sabre\DAVACL\Xml\Property\CurrentUserPrivilegeSet;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
 use Sabre\VObject\Component\VCalendar;
-use Sabre\VObject\Reader;
 
 /**
  * We can not directly use Sabre\CalDAV\Plugin because it's implementation of getCalendarHomeForPrincipal make a false assumption in the case of our DAV backend about the URL of users
@@ -97,249 +94,18 @@ class Plugin extends \Sabre\CalDAV\Plugin {
     /**
      * This function handles the calendar-query REPORT.
      *
-     * The stock Sabre implementation fetches the matching URIs with a single
-     * query but then reloads every object one at a time through
-     * getPropertiesForPath(). On a calendar holding tens of thousands of events
-     * that N+1 turns a filter-less REPORT (the one issued by the reindex task,
-     * see linagora/esn-sabre#403) into as many Mongo round-trips as there are
-     * objects, which blows past every reasonable timeout.
-     *
-     * We override the Depth: 1 calendar-collection case to fetch the calendar
-     * data of all matching objects in a single batch, exactly like
-     * ICSExportPlugin does for export. Every other shape (direct object,
-     * Depth: 0, ...) is rare and left to the stock implementation.
+     * The ESN specific overrides live in {@see Report} so that the report
+     * handling stays isolated from the rest of the plugin. We only keep the
+     * override entrypoint here (Sabre dispatches the report to this method) and
+     * delegate, providing the stock implementation as a fallback.
      *
      * @param \Sabre\CalDAV\Xml\Request\CalendarQueryReport $report
      * @return void
      */
     function calendarQueryReport($report) {
-        $path = $this->server->getRequestUri();
-        $node = $this->server->tree->getNodeForPath($path);
-        $depth = $this->server->getHTTPDepth(0);
-
-        if (!($node instanceof ICalendarObjectContainer) || $depth != 1) {
+        (new Report($this->server))->calendarQueryReport($report, function () use ($report) {
             parent::calendarQueryReport($report);
-
-            return;
-        }
-
-        $needsJson = $report->contentType === 'application/calendar+json';
-
-        $calendarTimeZone = null;
-        if ($report->expand) {
-            // We're expanding, and for that we need to figure out the
-            // calendar's timezone.
-            $tzProp = '{' . self::NS_CALDAV . '}calendar-timezone';
-            $tzResult = $this->server->getProperties($path, [$tzProp]);
-            if (isset($tzResult[$tzProp])) {
-                $vtimezoneObj = Reader::read($tzResult[$tzProp]);
-                $calendarTimeZone = $vtimezoneObj->VTIMEZONE->getTimeZone();
-                $vtimezoneObj->destroy();
-            } else {
-                $calendarTimeZone = new DateTimeZone('UTC');
-            }
-        }
-
-        $result = $this->buildCalendarQueryReportResult($report, $path, $node, $needsJson, $calendarTimeZone);
-
-        $prefer = $this->server->getHTTPPrefer();
-
-        $this->server->httpResponse->setStatus(207);
-        $this->server->httpResponse->setHeader('Content-Type', 'application/xml; charset=utf-8');
-        $this->server->httpResponse->setHeader('Vary', 'Brief,Prefer');
-        $this->server->httpResponse->setBody($this->server->generateMultiStatus($result, $prefer['return'] === 'minimal'));
-    }
-
-    /**
-     * Builds the multistatus response entries for a Depth: 1 calendar-query
-     * REPORT on a calendar collection.
-     *
-     * The matching URIs are resolved with a single query and their properties
-     * are fetched in one batch through getPropertiesForMultiplePaths(), turning
-     * the stock per-object N+1 into a single additional query.
-     *
-     * @param \Sabre\CalDAV\Xml\Request\CalendarQueryReport $report
-     * @param string $path
-     * @param ICalendarObjectContainer $node
-     * @param bool $needsJson
-     * @param DateTimeZone|null $calendarTimeZone
-     * @return array
-     */
-    protected function buildCalendarQueryReportResult($report, $path, ICalendarObjectContainer $node, $needsJson, $calendarTimeZone) {
-        if ($this->canReportFromSingleQuery($report, $node)) {
-            return $this->buildCalendarQueryReportResultFromSingleQuery($report, $path, $node, $needsJson);
-        }
-
-        $calendarDataProp = '{' . self::NS_CALDAV . '}calendar-data';
-
-        $nodePaths = $node->calendarQuery($report->filters);
-
-        $paths = array_map(function ($nodePath) use ($path) {
-            return $path . '/' . $nodePath;
-        }, $nodePaths);
-
-        $result = [];
-        foreach ($this->server->getPropertiesForMultiplePaths($paths, $report->properties) as $properties) {
-            if (($needsJson || $report->expand) && isset($properties[200][$calendarDataProp])) {
-                $vObject = Reader::read($properties[200][$calendarDataProp]);
-
-                if ($report->expand) {
-                    $vObject = $vObject->expand($report->expand['start'], $report->expand['end'], $calendarTimeZone);
-                }
-
-                if ($needsJson) {
-                    $properties[200][$calendarDataProp] = json_encode($vObject->jsonSerialize());
-                } else {
-                    $properties[200][$calendarDataProp] = $vObject->serialize();
-                }
-
-                // Destroy circular references so PHP will garbage collect the
-                // object.
-                $vObject->destroy();
-            }
-
-            $result[] = $properties;
-        }
-
-        return $result;
-    }
-
-    /**
-     * Whether the calendar-query REPORT can be answered straight from a single
-     * Mongo query (uri + calendardata + etag) without going through
-     * getPropertiesForMultiplePaths at all.
-     *
-     * This is the common filter-less case (the reindex REPORT): the objects are
-     * already returned with their data by the query, so we skip the extra node
-     * resolution round-trip entirely and parse each object at most once.
-     *
-     * We stay conservative: anything with a real filter, an expand, a non-Mongo
-     * backend, or a requested property we cannot synthesise from the query
-     * result falls back to the standard (batched) path.
-     *
-     * @param \Sabre\CalDAV\Xml\Request\CalendarQueryReport $report
-     * @param ICalendarObjectContainer $node
-     * @return bool
-     */
-    private function canReportFromSingleQuery($report, ICalendarObjectContainer $node) {
-        if ($report->expand) {
-            return false;
-        }
-
-        if (!($node instanceof SharedCalendar) || !($node->getBackend() instanceof Backend\Mongo)) {
-            return false;
-        }
-
-        $filters = $report->filters;
-        if (!empty($filters['prop-filters']) || !empty($filters['comp-filters'])) {
-            return false;
-        }
-
-        if (empty($report->properties)) {
-            return false;
-        }
-
-        $servable = ['{DAV:}getetag', '{' . self::NS_CALDAV . '}calendar-data'];
-        foreach ($report->properties as $property) {
-            if (!in_array($property, $servable, true)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Builds the multistatus entries for a filter-less calendar-query REPORT
-     * directly from calendarQueryWithAllData(), i.e. a single query returning
-     * uri + calendardata + etag for every object.
-     *
-     * @param \Sabre\CalDAV\Xml\Request\CalendarQueryReport $report
-     * @param string $path
-     * @param SharedCalendar $node
-     * @param bool $needsJson
-     * @return array
-     */
-    private function buildCalendarQueryReportResultFromSingleQuery($report, $path, SharedCalendar $node, $needsJson) {
-        $calendarDataProp = '{' . self::NS_CALDAV . '}calendar-data';
-        $etagProp = '{DAV:}getetag';
-
-        $wantsCalendarData = in_array($calendarDataProp, $report->properties, true);
-        $wantsEtag = in_array($etagProp, $report->properties, true);
-
-        $currentUser = $this->getCurrentUserPrincipal();
-        $calendarOwner = $node->getOwner();
-        // Same rule as PrivateEventPlugin: a delegate (not the calendar owner)
-        // only sees a sanitized version of PRIVATE / CONFIDENTIAL events.
-        $sanitizeForDelegate = $currentUser !== null && $calendarOwner !== null && $calendarOwner !== $currentUser;
-
-        $result = [];
-        foreach ($node->getBackend()->calendarQueryWithAllData($node->getFullCalendarId(), $report->filters) as $object) {
-            $properties = [];
-
-            if ($wantsCalendarData) {
-                $properties[$calendarDataProp] = $this->renderCalendarData($object, $node, $currentUser, $sanitizeForDelegate, $needsJson);
-            }
-            if ($wantsEtag) {
-                $properties[$etagProp] = $object['etag'];
-            }
-
-            $result[] = [
-                200 => $properties,
-                404 => [],
-                'href' => $path . '/' . $object['uri']
-            ];
-        }
-
-        return $result;
-    }
-
-    /**
-     * Renders the calendar-data of a single query result, applying the same
-     * private-event sanitization PrivateEventPlugin would apply on the standard
-     * propFind path. Non-private objects are returned verbatim without being
-     * parsed, so their serialization is byte-for-byte identical to the standard
-     * path.
-     *
-     * @param array $object Query result with uri/calendardata/etag/classification
-     * @param SharedCalendar $node
-     * @param string|null $currentUser
-     * @param bool $sanitizeForDelegate
-     * @param bool $needsJson
-     * @return string
-     */
-    private function renderCalendarData($object, SharedCalendar $node, $currentUser, $sanitizeForDelegate, $needsJson) {
-        $classification = isset($object['classification']) ? strtoupper($object['classification']) : null;
-        $needsSanitization = $sanitizeForDelegate
-            && ($classification === 'PRIVATE' || $classification === 'CONFIDENTIAL');
-
-        if (!$needsJson && !$needsSanitization) {
-            return $object['calendardata'];
-        }
-
-        $vObject = isset($object['vObject']) && $object['vObject'] !== null
-            ? $object['vObject']
-            : Reader::read($object['calendardata']);
-
-        $rendered = $vObject;
-        if ($needsSanitization) {
-            $rendered = \ESN\Utils\Utils::hidePrivateEventInfoForUser($vObject, $node, $currentUser);
-        }
-
-        $data = $needsJson ? json_encode($rendered->jsonSerialize()) : $rendered->serialize();
-
-        if ($rendered !== $vObject) {
-            $rendered->destroy();
-        }
-        $vObject->destroy();
-
-        return $data;
-    }
-
-    private function getCurrentUserPrincipal() {
-        $authPlugin = $this->server->getPlugin('auth');
-
-        return $authPlugin ? $authPlugin->getCurrentPrincipal() : null;
+        });
     }
 
 }

--- a/lib/CalDAV/Plugin.php
+++ b/lib/CalDAV/Plugin.php
@@ -1,8 +1,10 @@
 <?php
 namespace ESN\CalDAV;
 
+use DateTimeZone;
 use ESN\CalDAV\Validation\CalendarObjectValidator;
 use ESN\DAV\Sharing\Plugin as SPlugin;
+use Sabre\CalDAV\ICalendarObjectContainer;
 use Sabre\DAV\Exception\BadRequest;
 use Sabre\DAV\Exception\UnsupportedMediaType;
 use Sabre\DAV\INode;
@@ -12,6 +14,7 @@ use Sabre\DAVACL\Xml\Property\CurrentUserPrivilegeSet;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
 use Sabre\VObject\Component\VCalendar;
+use Sabre\VObject\Reader;
 
 /**
  * We can not directly use Sabre\CalDAV\Plugin because it's implementation of getCalendarHomeForPrincipal make a false assumption in the case of our DAV backend about the URL of users
@@ -89,6 +92,112 @@ class Plugin extends \Sabre\CalDAV\Plugin {
         }
 
         return;
+    }
+
+    /**
+     * This function handles the calendar-query REPORT.
+     *
+     * The stock Sabre implementation fetches the matching URIs with a single
+     * query but then reloads every object one at a time through
+     * getPropertiesForPath(). On a calendar holding tens of thousands of events
+     * that N+1 turns a filter-less REPORT (the one issued by the reindex task,
+     * see linagora/esn-sabre#403) into as many Mongo round-trips as there are
+     * objects, which blows past every reasonable timeout.
+     *
+     * We override the Depth: 1 calendar-collection case to fetch the calendar
+     * data of all matching objects in a single batch, exactly like
+     * ICSExportPlugin does for export. Every other shape (direct object,
+     * Depth: 0, ...) is rare and left to the stock implementation.
+     *
+     * @param \Sabre\CalDAV\Xml\Request\CalendarQueryReport $report
+     * @return void
+     */
+    function calendarQueryReport($report) {
+        $path = $this->server->getRequestUri();
+        $node = $this->server->tree->getNodeForPath($path);
+        $depth = $this->server->getHTTPDepth(0);
+
+        if (!($node instanceof ICalendarObjectContainer) || $depth != 1) {
+            parent::calendarQueryReport($report);
+
+            return;
+        }
+
+        $needsJson = $report->contentType === 'application/calendar+json';
+
+        $calendarTimeZone = null;
+        if ($report->expand) {
+            // We're expanding, and for that we need to figure out the
+            // calendar's timezone.
+            $tzProp = '{' . self::NS_CALDAV . '}calendar-timezone';
+            $tzResult = $this->server->getProperties($path, [$tzProp]);
+            if (isset($tzResult[$tzProp])) {
+                $vtimezoneObj = Reader::read($tzResult[$tzProp]);
+                $calendarTimeZone = $vtimezoneObj->VTIMEZONE->getTimeZone();
+                $vtimezoneObj->destroy();
+            } else {
+                $calendarTimeZone = new DateTimeZone('UTC');
+            }
+        }
+
+        $result = $this->buildCalendarQueryReportResult($report, $path, $node, $needsJson, $calendarTimeZone);
+
+        $prefer = $this->server->getHTTPPrefer();
+
+        $this->server->httpResponse->setStatus(207);
+        $this->server->httpResponse->setHeader('Content-Type', 'application/xml; charset=utf-8');
+        $this->server->httpResponse->setHeader('Vary', 'Brief,Prefer');
+        $this->server->httpResponse->setBody($this->server->generateMultiStatus($result, $prefer['return'] === 'minimal'));
+    }
+
+    /**
+     * Builds the multistatus response entries for a Depth: 1 calendar-query
+     * REPORT on a calendar collection.
+     *
+     * The matching URIs are resolved with a single query and their properties
+     * are fetched in one batch through getPropertiesForMultiplePaths(), turning
+     * the stock per-object N+1 into a single additional query.
+     *
+     * @param \Sabre\CalDAV\Xml\Request\CalendarQueryReport $report
+     * @param string $path
+     * @param ICalendarObjectContainer $node
+     * @param bool $needsJson
+     * @param DateTimeZone|null $calendarTimeZone
+     * @return array
+     */
+    protected function buildCalendarQueryReportResult($report, $path, ICalendarObjectContainer $node, $needsJson, $calendarTimeZone) {
+        $calendarDataProp = '{' . self::NS_CALDAV . '}calendar-data';
+
+        $nodePaths = $node->calendarQuery($report->filters);
+
+        $paths = array_map(function ($nodePath) use ($path) {
+            return $path . '/' . $nodePath;
+        }, $nodePaths);
+
+        $result = [];
+        foreach ($this->server->getPropertiesForMultiplePaths($paths, $report->properties) as $properties) {
+            if (($needsJson || $report->expand) && isset($properties[200][$calendarDataProp])) {
+                $vObject = Reader::read($properties[200][$calendarDataProp]);
+
+                if ($report->expand) {
+                    $vObject = $vObject->expand($report->expand['start'], $report->expand['end'], $calendarTimeZone);
+                }
+
+                if ($needsJson) {
+                    $properties[200][$calendarDataProp] = json_encode($vObject->jsonSerialize());
+                } else {
+                    $properties[200][$calendarDataProp] = $vObject->serialize();
+                }
+
+                // Destroy circular references so PHP will garbage collect the
+                // object.
+                $vObject->destroy();
+            }
+
+            $result[] = $properties;
+        }
+
+        return $result;
     }
 
 }

--- a/lib/CalDAV/Report.php
+++ b/lib/CalDAV/Report.php
@@ -51,222 +51,122 @@ class Report {
             return;
         }
 
-        $needsJson = $report->contentType === 'application/calendar+json';
-
-        $calendarTimeZone = null;
-        if ($report->expand) {
-            // We're expanding, and for that we need to figure out the
-            // calendar's timezone.
-            $tzProp = '{' . self::NS_CALDAV . '}calendar-timezone';
-            $tzResult = $this->server->getProperties($path, [$tzProp]);
-            if (isset($tzResult[$tzProp])) {
-                $vtimezoneObj = Reader::read($tzResult[$tzProp]);
-                $calendarTimeZone = $vtimezoneObj->VTIMEZONE->getTimeZone();
-                $vtimezoneObj->destroy();
-            } else {
-                $calendarTimeZone = new DateTimeZone('UTC');
-            }
-        }
-
-        $result = $this->buildCalendarQueryReportResult($report, $path, $node, $needsJson, $calendarTimeZone);
-
-        $prefer = $this->server->getHTTPPrefer();
-
-        $this->server->httpResponse->setStatus(207);
-        $this->server->httpResponse->setHeader('Content-Type', 'application/xml; charset=utf-8');
-        $this->server->httpResponse->setHeader('Vary', 'Brief,Prefer');
-        $this->server->httpResponse->setBody($this->server->generateMultiStatus($result, $prefer['return'] === 'minimal'));
+        $this->sendMultiStatus($this->buildCalendarQueryReportResult($report, $path, $node));
     }
 
     /**
      * Builds the multistatus response entries for a Depth: 1 calendar-query
      * REPORT on a calendar collection.
      *
-     * The matching URIs are resolved with a single query and their properties
-     * are fetched in one batch through getPropertiesForMultiplePaths(), turning
-     * the stock per-object N+1 into a single additional query.
+     * The filter-less case is served straight from a single query (see
+     * {@see SingleQueryReport}); every other shape resolves the matching URIs
+     * and fetches their properties in one batch through
+     * getPropertiesForMultiplePaths(), turning the stock per-object N+1 into a
+     * single additional query.
      *
      * @param \Sabre\CalDAV\Xml\Request\CalendarQueryReport $report
      * @param string $path
      * @param ICalendarObjectContainer $node
+     * @return array
+     */
+    protected function buildCalendarQueryReportResult($report, $path, ICalendarObjectContainer $node) {
+        $singleQueryResult = (new SingleQueryReport($this->server))->tryBuild($report, $path, $node);
+        if ($singleQueryResult !== null) {
+            return $singleQueryResult;
+        }
+
+        return $this->buildBatchedResult($report, $path, $node);
+    }
+
+    /**
+     * Standard path: resolve the matching URIs then fetch their properties in a
+     * single batch, rendering calendar-data (json/expand) as needed.
+     *
+     * @param \Sabre\CalDAV\Xml\Request\CalendarQueryReport $report
+     * @param string $path
+     * @param ICalendarObjectContainer $node
+     * @return array
+     */
+    private function buildBatchedResult($report, $path, ICalendarObjectContainer $node) {
+        $needsJson = $report->contentType === 'application/calendar+json';
+        $calendarTimeZone = $report->expand ? $this->resolveCalendarTimeZone($path) : null;
+
+        $paths = array_map(function ($nodePath) use ($path) {
+            return $path . '/' . $nodePath;
+        }, $node->calendarQuery($report->filters));
+
+        $result = [];
+        foreach ($this->server->getPropertiesForMultiplePaths($paths, $report->properties) as $properties) {
+            $result[] = $this->renderBatchedProperties($properties, $report, $needsJson, $calendarTimeZone);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Renders the calendar-data of a single getPropertiesForMultiplePaths entry
+     * when the client asked for json output or an expand; otherwise the entry is
+     * returned untouched.
+     *
+     * @param array $properties
+     * @param \Sabre\CalDAV\Xml\Request\CalendarQueryReport $report
      * @param bool $needsJson
      * @param DateTimeZone|null $calendarTimeZone
      * @return array
      */
-    protected function buildCalendarQueryReportResult($report, $path, ICalendarObjectContainer $node, $needsJson, $calendarTimeZone) {
-        if ($this->canReportFromSingleQuery($report, $node)) {
-            return $this->buildCalendarQueryReportResultFromSingleQuery($report, $path, $node, $needsJson);
-        }
-
+    private function renderBatchedProperties($properties, $report, $needsJson, $calendarTimeZone) {
         $calendarDataProp = '{' . self::NS_CALDAV . '}calendar-data';
 
-        $nodePaths = $node->calendarQuery($report->filters);
-
-        $paths = array_map(function ($nodePath) use ($path) {
-            return $path . '/' . $nodePath;
-        }, $nodePaths);
-
-        $result = [];
-        foreach ($this->server->getPropertiesForMultiplePaths($paths, $report->properties) as $properties) {
-            if (($needsJson || $report->expand) && isset($properties[200][$calendarDataProp])) {
-                $vObject = Reader::read($properties[200][$calendarDataProp]);
-
-                if ($report->expand) {
-                    $vObject = $vObject->expand($report->expand['start'], $report->expand['end'], $calendarTimeZone);
-                }
-
-                if ($needsJson) {
-                    $properties[200][$calendarDataProp] = json_encode($vObject->jsonSerialize());
-                } else {
-                    $properties[200][$calendarDataProp] = $vObject->serialize();
-                }
-
-                // Destroy circular references so PHP will garbage collect the
-                // object.
-                $vObject->destroy();
-            }
-
-            $result[] = $properties;
+        if (!$needsJson && !$report->expand) {
+            return $properties;
+        }
+        if (!isset($properties[200][$calendarDataProp])) {
+            return $properties;
         }
 
-        return $result;
-    }
+        $vObject = Reader::read($properties[200][$calendarDataProp]);
 
-    /**
-     * Whether the calendar-query REPORT can be answered straight from a single
-     * Mongo query (uri + calendardata + etag) without going through
-     * getPropertiesForMultiplePaths at all.
-     *
-     * This is the common filter-less case (the reindex REPORT): the objects are
-     * already returned with their data by the query, so we skip the extra node
-     * resolution round-trip entirely and parse each object at most once.
-     *
-     * We stay conservative: anything with a real filter, an expand, a non-Mongo
-     * backend, or a requested property we cannot synthesise from the query
-     * result falls back to the standard (batched) path.
-     *
-     * @param \Sabre\CalDAV\Xml\Request\CalendarQueryReport $report
-     * @param ICalendarObjectContainer $node
-     * @return bool
-     */
-    private function canReportFromSingleQuery($report, ICalendarObjectContainer $node) {
         if ($report->expand) {
-            return false;
+            $vObject = $vObject->expand($report->expand['start'], $report->expand['end'], $calendarTimeZone);
         }
 
-        if (!($node instanceof SharedCalendar) || !($node->getBackend() instanceof Backend\Mongo)) {
-            return false;
-        }
+        $properties[200][$calendarDataProp] = $needsJson
+            ? json_encode($vObject->jsonSerialize())
+            : $vObject->serialize();
 
-        $filters = $report->filters;
-        if (!empty($filters['prop-filters']) || !empty($filters['comp-filters'])) {
-            return false;
-        }
-
-        if (empty($report->properties)) {
-            return false;
-        }
-
-        $servable = ['{DAV:}getetag', '{' . self::NS_CALDAV . '}calendar-data'];
-        foreach ($report->properties as $property) {
-            if (!in_array($property, $servable, true)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Builds the multistatus entries for a filter-less calendar-query REPORT
-     * directly from calendarQueryWithAllData(), i.e. a single query returning
-     * uri + calendardata + etag for every object.
-     *
-     * @param \Sabre\CalDAV\Xml\Request\CalendarQueryReport $report
-     * @param string $path
-     * @param SharedCalendar $node
-     * @param bool $needsJson
-     * @return array
-     */
-    private function buildCalendarQueryReportResultFromSingleQuery($report, $path, SharedCalendar $node, $needsJson) {
-        $calendarDataProp = '{' . self::NS_CALDAV . '}calendar-data';
-        $etagProp = '{DAV:}getetag';
-
-        $wantsCalendarData = in_array($calendarDataProp, $report->properties, true);
-        $wantsEtag = in_array($etagProp, $report->properties, true);
-
-        $currentUser = $this->getCurrentUserPrincipal();
-        $calendarOwner = $node->getOwner();
-        // Same rule as PrivateEventPlugin: a delegate (not the calendar owner)
-        // only sees a sanitized version of PRIVATE / CONFIDENTIAL events.
-        $sanitizeForDelegate = $currentUser !== null && $calendarOwner !== null && $calendarOwner !== $currentUser;
-
-        $result = [];
-        foreach ($node->getBackend()->calendarQueryWithAllData($node->getFullCalendarId(), $report->filters) as $object) {
-            $properties = [];
-
-            if ($wantsCalendarData) {
-                $properties[$calendarDataProp] = $this->renderCalendarData($object, $node, $currentUser, $sanitizeForDelegate, $needsJson);
-            }
-            if ($wantsEtag) {
-                $properties[$etagProp] = $object['etag'];
-            }
-
-            $result[] = [
-                200 => $properties,
-                404 => [],
-                'href' => $path . '/' . $object['uri']
-            ];
-        }
-
-        return $result;
-    }
-
-    /**
-     * Renders the calendar-data of a single query result, applying the same
-     * private-event sanitization PrivateEventPlugin would apply on the standard
-     * propFind path. Non-private objects are returned verbatim without being
-     * parsed, so their serialization is byte-for-byte identical to the standard
-     * path.
-     *
-     * @param array $object Query result with uri/calendardata/etag/classification
-     * @param SharedCalendar $node
-     * @param string|null $currentUser
-     * @param bool $sanitizeForDelegate
-     * @param bool $needsJson
-     * @return string
-     */
-    private function renderCalendarData($object, SharedCalendar $node, $currentUser, $sanitizeForDelegate, $needsJson) {
-        $classification = isset($object['classification']) ? strtoupper($object['classification']) : null;
-        $needsSanitization = $sanitizeForDelegate
-            && ($classification === 'PRIVATE' || $classification === 'CONFIDENTIAL');
-
-        if (!$needsJson && !$needsSanitization) {
-            return $object['calendardata'];
-        }
-
-        $vObject = isset($object['vObject']) && $object['vObject'] !== null
-            ? $object['vObject']
-            : Reader::read($object['calendardata']);
-
-        $rendered = $vObject;
-        if ($needsSanitization) {
-            $rendered = \ESN\Utils\Utils::hidePrivateEventInfoForUser($vObject, $node, $currentUser);
-        }
-
-        $data = $needsJson ? json_encode($rendered->jsonSerialize()) : $rendered->serialize();
-
-        if ($rendered !== $vObject) {
-            $rendered->destroy();
-        }
+        // Destroy circular references so PHP will garbage collect the object.
         $vObject->destroy();
 
-        return $data;
+        return $properties;
     }
 
-    private function getCurrentUserPrincipal() {
-        $authPlugin = $this->server->getPlugin('auth');
+    /**
+     * Figures out the calendar's timezone, needed when expanding recurrences.
+     *
+     * @param string $path
+     * @return DateTimeZone
+     */
+    private function resolveCalendarTimeZone($path) {
+        $tzProp = '{' . self::NS_CALDAV . '}calendar-timezone';
+        $tzResult = $this->server->getProperties($path, [$tzProp]);
 
-        return $authPlugin ? $authPlugin->getCurrentPrincipal() : null;
+        if (!isset($tzResult[$tzProp])) {
+            return new DateTimeZone('UTC');
+        }
+
+        $vtimezoneObj = Reader::read($tzResult[$tzProp]);
+        $calendarTimeZone = $vtimezoneObj->VTIMEZONE->getTimeZone();
+        $vtimezoneObj->destroy();
+
+        return $calendarTimeZone;
+    }
+
+    private function sendMultiStatus($result) {
+        $prefer = $this->server->getHTTPPrefer();
+
+        $this->server->httpResponse->setStatus(207);
+        $this->server->httpResponse->setHeader('Content-Type', 'application/xml; charset=utf-8');
+        $this->server->httpResponse->setHeader('Vary', 'Brief,Prefer');
+        $this->server->httpResponse->setBody($this->server->generateMultiStatus($result, $prefer['return'] === 'minimal'));
     }
 }

--- a/lib/CalDAV/Report.php
+++ b/lib/CalDAV/Report.php
@@ -1,0 +1,272 @@
+<?php
+namespace ESN\CalDAV;
+
+use DateTimeZone;
+use Sabre\CalDAV\ICalendarObjectContainer;
+use Sabre\DAV\Server;
+use Sabre\VObject\Reader;
+
+/**
+ * Holds the ESN specific calendar-query REPORT overrides so that they are
+ * isolated from the rest of the MongoDB CalDAV Plugin. The Plugin simply
+ * delegates its report handling to this class.
+ */
+class Report {
+    const NS_CALDAV = \Sabre\CalDAV\Plugin::NS_CALDAV;
+
+    private $server;
+
+    function __construct(Server $server) {
+        $this->server = $server;
+    }
+
+    /**
+     * This function handles the calendar-query REPORT.
+     *
+     * The stock Sabre implementation fetches the matching URIs with a single
+     * query but then reloads every object one at a time through
+     * getPropertiesForPath(). On a calendar holding tens of thousands of events
+     * that N+1 turns a filter-less REPORT (the one issued by the reindex task,
+     * see linagora/esn-sabre#403) into as many Mongo round-trips as there are
+     * objects, which blows past every reasonable timeout.
+     *
+     * We override the Depth: 1 calendar-collection case to fetch the calendar
+     * data of all matching objects in a single batch, exactly like
+     * ICSExportPlugin does for export. Every other shape (direct object,
+     * Depth: 0, ...) is rare and delegated to $fallback, which runs the stock
+     * implementation.
+     *
+     * @param \Sabre\CalDAV\Xml\Request\CalendarQueryReport $report
+     * @param callable $fallback Runs the stock Sabre implementation.
+     * @return void
+     */
+    function calendarQueryReport($report, callable $fallback) {
+        $path = $this->server->getRequestUri();
+        $node = $this->server->tree->getNodeForPath($path);
+        $depth = $this->server->getHTTPDepth(0);
+
+        if (!($node instanceof ICalendarObjectContainer) || $depth != 1) {
+            $fallback();
+
+            return;
+        }
+
+        $needsJson = $report->contentType === 'application/calendar+json';
+
+        $calendarTimeZone = null;
+        if ($report->expand) {
+            // We're expanding, and for that we need to figure out the
+            // calendar's timezone.
+            $tzProp = '{' . self::NS_CALDAV . '}calendar-timezone';
+            $tzResult = $this->server->getProperties($path, [$tzProp]);
+            if (isset($tzResult[$tzProp])) {
+                $vtimezoneObj = Reader::read($tzResult[$tzProp]);
+                $calendarTimeZone = $vtimezoneObj->VTIMEZONE->getTimeZone();
+                $vtimezoneObj->destroy();
+            } else {
+                $calendarTimeZone = new DateTimeZone('UTC');
+            }
+        }
+
+        $result = $this->buildCalendarQueryReportResult($report, $path, $node, $needsJson, $calendarTimeZone);
+
+        $prefer = $this->server->getHTTPPrefer();
+
+        $this->server->httpResponse->setStatus(207);
+        $this->server->httpResponse->setHeader('Content-Type', 'application/xml; charset=utf-8');
+        $this->server->httpResponse->setHeader('Vary', 'Brief,Prefer');
+        $this->server->httpResponse->setBody($this->server->generateMultiStatus($result, $prefer['return'] === 'minimal'));
+    }
+
+    /**
+     * Builds the multistatus response entries for a Depth: 1 calendar-query
+     * REPORT on a calendar collection.
+     *
+     * The matching URIs are resolved with a single query and their properties
+     * are fetched in one batch through getPropertiesForMultiplePaths(), turning
+     * the stock per-object N+1 into a single additional query.
+     *
+     * @param \Sabre\CalDAV\Xml\Request\CalendarQueryReport $report
+     * @param string $path
+     * @param ICalendarObjectContainer $node
+     * @param bool $needsJson
+     * @param DateTimeZone|null $calendarTimeZone
+     * @return array
+     */
+    protected function buildCalendarQueryReportResult($report, $path, ICalendarObjectContainer $node, $needsJson, $calendarTimeZone) {
+        if ($this->canReportFromSingleQuery($report, $node)) {
+            return $this->buildCalendarQueryReportResultFromSingleQuery($report, $path, $node, $needsJson);
+        }
+
+        $calendarDataProp = '{' . self::NS_CALDAV . '}calendar-data';
+
+        $nodePaths = $node->calendarQuery($report->filters);
+
+        $paths = array_map(function ($nodePath) use ($path) {
+            return $path . '/' . $nodePath;
+        }, $nodePaths);
+
+        $result = [];
+        foreach ($this->server->getPropertiesForMultiplePaths($paths, $report->properties) as $properties) {
+            if (($needsJson || $report->expand) && isset($properties[200][$calendarDataProp])) {
+                $vObject = Reader::read($properties[200][$calendarDataProp]);
+
+                if ($report->expand) {
+                    $vObject = $vObject->expand($report->expand['start'], $report->expand['end'], $calendarTimeZone);
+                }
+
+                if ($needsJson) {
+                    $properties[200][$calendarDataProp] = json_encode($vObject->jsonSerialize());
+                } else {
+                    $properties[200][$calendarDataProp] = $vObject->serialize();
+                }
+
+                // Destroy circular references so PHP will garbage collect the
+                // object.
+                $vObject->destroy();
+            }
+
+            $result[] = $properties;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Whether the calendar-query REPORT can be answered straight from a single
+     * Mongo query (uri + calendardata + etag) without going through
+     * getPropertiesForMultiplePaths at all.
+     *
+     * This is the common filter-less case (the reindex REPORT): the objects are
+     * already returned with their data by the query, so we skip the extra node
+     * resolution round-trip entirely and parse each object at most once.
+     *
+     * We stay conservative: anything with a real filter, an expand, a non-Mongo
+     * backend, or a requested property we cannot synthesise from the query
+     * result falls back to the standard (batched) path.
+     *
+     * @param \Sabre\CalDAV\Xml\Request\CalendarQueryReport $report
+     * @param ICalendarObjectContainer $node
+     * @return bool
+     */
+    private function canReportFromSingleQuery($report, ICalendarObjectContainer $node) {
+        if ($report->expand) {
+            return false;
+        }
+
+        if (!($node instanceof SharedCalendar) || !($node->getBackend() instanceof Backend\Mongo)) {
+            return false;
+        }
+
+        $filters = $report->filters;
+        if (!empty($filters['prop-filters']) || !empty($filters['comp-filters'])) {
+            return false;
+        }
+
+        if (empty($report->properties)) {
+            return false;
+        }
+
+        $servable = ['{DAV:}getetag', '{' . self::NS_CALDAV . '}calendar-data'];
+        foreach ($report->properties as $property) {
+            if (!in_array($property, $servable, true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Builds the multistatus entries for a filter-less calendar-query REPORT
+     * directly from calendarQueryWithAllData(), i.e. a single query returning
+     * uri + calendardata + etag for every object.
+     *
+     * @param \Sabre\CalDAV\Xml\Request\CalendarQueryReport $report
+     * @param string $path
+     * @param SharedCalendar $node
+     * @param bool $needsJson
+     * @return array
+     */
+    private function buildCalendarQueryReportResultFromSingleQuery($report, $path, SharedCalendar $node, $needsJson) {
+        $calendarDataProp = '{' . self::NS_CALDAV . '}calendar-data';
+        $etagProp = '{DAV:}getetag';
+
+        $wantsCalendarData = in_array($calendarDataProp, $report->properties, true);
+        $wantsEtag = in_array($etagProp, $report->properties, true);
+
+        $currentUser = $this->getCurrentUserPrincipal();
+        $calendarOwner = $node->getOwner();
+        // Same rule as PrivateEventPlugin: a delegate (not the calendar owner)
+        // only sees a sanitized version of PRIVATE / CONFIDENTIAL events.
+        $sanitizeForDelegate = $currentUser !== null && $calendarOwner !== null && $calendarOwner !== $currentUser;
+
+        $result = [];
+        foreach ($node->getBackend()->calendarQueryWithAllData($node->getFullCalendarId(), $report->filters) as $object) {
+            $properties = [];
+
+            if ($wantsCalendarData) {
+                $properties[$calendarDataProp] = $this->renderCalendarData($object, $node, $currentUser, $sanitizeForDelegate, $needsJson);
+            }
+            if ($wantsEtag) {
+                $properties[$etagProp] = $object['etag'];
+            }
+
+            $result[] = [
+                200 => $properties,
+                404 => [],
+                'href' => $path . '/' . $object['uri']
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Renders the calendar-data of a single query result, applying the same
+     * private-event sanitization PrivateEventPlugin would apply on the standard
+     * propFind path. Non-private objects are returned verbatim without being
+     * parsed, so their serialization is byte-for-byte identical to the standard
+     * path.
+     *
+     * @param array $object Query result with uri/calendardata/etag/classification
+     * @param SharedCalendar $node
+     * @param string|null $currentUser
+     * @param bool $sanitizeForDelegate
+     * @param bool $needsJson
+     * @return string
+     */
+    private function renderCalendarData($object, SharedCalendar $node, $currentUser, $sanitizeForDelegate, $needsJson) {
+        $classification = isset($object['classification']) ? strtoupper($object['classification']) : null;
+        $needsSanitization = $sanitizeForDelegate
+            && ($classification === 'PRIVATE' || $classification === 'CONFIDENTIAL');
+
+        if (!$needsJson && !$needsSanitization) {
+            return $object['calendardata'];
+        }
+
+        $vObject = isset($object['vObject']) && $object['vObject'] !== null
+            ? $object['vObject']
+            : Reader::read($object['calendardata']);
+
+        $rendered = $vObject;
+        if ($needsSanitization) {
+            $rendered = \ESN\Utils\Utils::hidePrivateEventInfoForUser($vObject, $node, $currentUser);
+        }
+
+        $data = $needsJson ? json_encode($rendered->jsonSerialize()) : $rendered->serialize();
+
+        if ($rendered !== $vObject) {
+            $rendered->destroy();
+        }
+        $vObject->destroy();
+
+        return $data;
+    }
+
+    private function getCurrentUserPrincipal() {
+        $authPlugin = $this->server->getPlugin('auth');
+
+        return $authPlugin ? $authPlugin->getCurrentPrincipal() : null;
+    }
+}

--- a/lib/CalDAV/SingleQueryReport.php
+++ b/lib/CalDAV/SingleQueryReport.php
@@ -1,0 +1,200 @@
+<?php
+namespace ESN\CalDAV;
+
+use Sabre\CalDAV\ICalendarObjectContainer;
+use Sabre\DAV\Server;
+use Sabre\VObject\Reader;
+
+/**
+ * Answers the common filter-less calendar-query REPORT (the one issued by the
+ * reindex task, see linagora/esn-sabre#403) straight from a single Mongo query
+ * returning uri + calendardata + etag for every object, skipping the extra node
+ * resolution round-trip that getPropertiesForMultiplePaths performs.
+ *
+ * We stay conservative: anything with a real filter, an expand, a non-Mongo
+ * backend, or a requested property we cannot synthesise from the query result
+ * is left to the caller, which falls back to the standard (batched) path.
+ */
+class SingleQueryReport {
+    const NS_CALDAV = \Sabre\CalDAV\Plugin::NS_CALDAV;
+
+    private $server;
+
+    /** @var SharedCalendar The calendar the report runs against. */
+    private $node;
+
+    /** @var string|null The current user principal, resolved once per build. */
+    private $currentUser;
+
+    /** @var bool Whether PRIVATE / CONFIDENTIAL events must be sanitized. */
+    private $sanitizeForDelegate;
+
+    /** @var bool Whether calendar-data must be emitted as calendar+json. */
+    private $needsJson;
+
+    function __construct(Server $server) {
+        $this->server = $server;
+    }
+
+    /**
+     * Builds the multistatus entries for a filter-less calendar-query REPORT
+     * directly from calendarQueryWithAllData(), or returns null when the report
+     * cannot be served from a single query and the caller must fall back to the
+     * standard (batched) path.
+     *
+     * @param \Sabre\CalDAV\Xml\Request\CalendarQueryReport $report
+     * @param string $path
+     * @param ICalendarObjectContainer $node
+     * @return array|null
+     */
+    function tryBuild($report, $path, ICalendarObjectContainer $node) {
+        if (!$this->canReportFromSingleQuery($report, $node)) {
+            return null;
+        }
+
+        $calendarDataProp = '{' . self::NS_CALDAV . '}calendar-data';
+        $etagProp = '{DAV:}getetag';
+
+        $wantsCalendarData = in_array($calendarDataProp, $report->properties, true);
+        $wantsEtag = in_array($etagProp, $report->properties, true);
+
+        $this->prepareRenderContext($report, $node);
+
+        $result = [];
+        foreach ($node->getBackend()->calendarQueryWithAllData($node->getFullCalendarId(), $report->filters) as $object) {
+            $properties = [];
+
+            if ($wantsCalendarData) {
+                $properties[$calendarDataProp] = $this->renderCalendarData($object);
+            }
+            if ($wantsEtag) {
+                $properties[$etagProp] = $object['etag'];
+            }
+
+            $result[] = [
+                200 => $properties,
+                404 => [],
+                'href' => $path . '/' . $object['uri']
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Resolves the per-request state renderCalendarData() relies on: the target
+     * calendar, the current user and whether delegate sanitization applies.
+     *
+     * @param \Sabre\CalDAV\Xml\Request\CalendarQueryReport $report
+     * @param SharedCalendar $node
+     * @return void
+     */
+    private function prepareRenderContext($report, SharedCalendar $node) {
+        $this->node = $node;
+        $this->needsJson = $report->contentType === 'application/calendar+json';
+        $this->currentUser = $this->getCurrentUserPrincipal();
+
+        $calendarOwner = $node->getOwner();
+        // Same rule as PrivateEventPlugin: a delegate (not the calendar owner)
+        // only sees a sanitized version of PRIVATE / CONFIDENTIAL events.
+        $this->sanitizeForDelegate = $this->currentUser !== null && $calendarOwner !== null && $calendarOwner !== $this->currentUser;
+    }
+
+    /**
+     * Whether the calendar-query REPORT can be answered straight from a single
+     * Mongo query (uri + calendardata + etag) without going through
+     * getPropertiesForMultiplePaths at all.
+     *
+     * This is the common filter-less case (the reindex REPORT): the objects are
+     * already returned with their data by the query, so we skip the extra node
+     * resolution round-trip entirely and parse each object at most once.
+     *
+     * @param \Sabre\CalDAV\Xml\Request\CalendarQueryReport $report
+     * @param ICalendarObjectContainer $node
+     * @return bool
+     */
+    private function canReportFromSingleQuery($report, ICalendarObjectContainer $node) {
+        if ($report->expand) {
+            return false;
+        }
+
+        if (!$this->isMongoSharedCalendar($node)) {
+            return false;
+        }
+
+        if ($this->hasFilters($report)) {
+            return false;
+        }
+
+        return $this->requestsOnlyServableProperties($report);
+    }
+
+    private function isMongoSharedCalendar(ICalendarObjectContainer $node) {
+        return $node instanceof SharedCalendar && $node->getBackend() instanceof Backend\Mongo;
+    }
+
+    private function hasFilters($report) {
+        $filters = $report->filters;
+
+        return !empty($filters['prop-filters']) || !empty($filters['comp-filters']);
+    }
+
+    private function requestsOnlyServableProperties($report) {
+        if (empty($report->properties)) {
+            return false;
+        }
+
+        $servable = ['{DAV:}getetag', '{' . self::NS_CALDAV . '}calendar-data'];
+        foreach ($report->properties as $property) {
+            if (!in_array($property, $servable, true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Renders the calendar-data of a single query result, applying the same
+     * private-event sanitization PrivateEventPlugin would apply on the standard
+     * propFind path. Non-private objects are returned verbatim without being
+     * parsed, so their serialization is byte-for-byte identical to the standard
+     * path.
+     *
+     * @param array $object Query result with uri/calendardata/etag/classification
+     * @return string
+     */
+    private function renderCalendarData($object) {
+        $classification = isset($object['classification']) ? strtoupper($object['classification']) : null;
+        $needsSanitization = $this->sanitizeForDelegate
+            && ($classification === 'PRIVATE' || $classification === 'CONFIDENTIAL');
+
+        if (!$this->needsJson && !$needsSanitization) {
+            return $object['calendardata'];
+        }
+
+        $vObject = isset($object['vObject']) && $object['vObject'] !== null
+            ? $object['vObject']
+            : Reader::read($object['calendardata']);
+
+        $rendered = $vObject;
+        if ($needsSanitization) {
+            $rendered = \ESN\Utils\Utils::hidePrivateEventInfoForUser($vObject, $this->node, $this->currentUser);
+        }
+
+        $data = $this->needsJson ? json_encode($rendered->jsonSerialize()) : $rendered->serialize();
+
+        if ($rendered !== $vObject) {
+            $rendered->destroy();
+        }
+        $vObject->destroy();
+
+        return $data;
+    }
+
+    private function getCurrentUserPrincipal() {
+        $authPlugin = $this->server->getPlugin('auth');
+
+        return $authPlugin ? $authPlugin->getCurrentPrincipal() : null;
+    }
+}

--- a/lib/DAVACL/Plugin.php
+++ b/lib/DAVACL/Plugin.php
@@ -6,11 +6,20 @@ use Sabre\DAV;
 
 #[\AllowDynamicProperties]
 class Plugin extends \ESN\JSON\BasePlugin {
+    private const REPORT_READ_PRIVILEGES = [
+        '{DAV:}sync-collection' => '{DAV:}read',
+        '{urn:ietf:params:xml:ns:caldav}calendar-query' => '{DAV:}read',
+        '{urn:ietf:params:xml:ns:caldav}calendar-multiget' => '{DAV:}read',
+        '{urn:ietf:params:xml:ns:caldav}free-busy-query' => '{urn:ietf:params:xml:ns:caldav}read-free-busy',
+        '{urn:ietf:params:xml:ns:carddav}addressbook-query' => '{DAV:}read',
+        '{urn:ietf:params:xml:ns:carddav}addressbook-multiget' => '{DAV:}read',
+    ];
 
     function initialize(DAV\Server $server) {
         parent::initialize($server);
 
         $server->on('beforeMethod:PROPFIND', [$this, 'beforePropFind'], 20);
+        $server->on('report', [$this, 'beforeReport'], 20);
         $server->on('method:PROPFIND', [$this, 'propFind'], 80);
     }
 
@@ -27,6 +36,31 @@ class Plugin extends \ESN\JSON\BasePlugin {
         }
 
         return true;
+    }
+
+    public function beforeReport($reportName, $report, $path) {
+        if (!isset(self::REPORT_READ_PRIVILEGES[$reportName])) {
+            return true;
+        }
+
+        $paths = isset($report->hrefs) ? $report->hrefs : [$path];
+        foreach ($paths as $reportPath) {
+            $this->assertCanReadExistingPath($reportPath, self::REPORT_READ_PRIVILEGES[$reportName]);
+        }
+
+        return true;
+    }
+
+    private function assertCanReadExistingPath($path, $privilege) {
+        if (!$this->server->tree->nodeExists($path)) {
+            return;
+        }
+
+        $aclPlugin = $this->server->getPlugin('acl');
+        if ($aclPlugin) {
+            // Some REPORT handlers synthesize responses directly, bypassing propFind ACL checks.
+            $aclPlugin->checkPrivileges($path, $privilege, \Sabre\DAVACL\Plugin::R_PARENT);
+        }
     }
 
     public function propFind($request, $response) {

--- a/tests/CalDAV/CalendarQueryReportTest.php
+++ b/tests/CalDAV/CalendarQueryReportTest.php
@@ -151,6 +151,42 @@ class CalendarQueryReportTest extends \ESN\DAV\ServerMock {
         $this->assertArrayHasKey('/calendars/54b64eadf6d7d8e41d263e0f/calendar1/event2.ics', $items);
     }
 
+    function testFilterlessReportReturnsFullPrivateDataToOwner() {
+        $privateEvent = implode("\r\n", [
+            'BEGIN:VCALENDAR',
+            'VERSION:2.0',
+            'PRODID:-//test//EN',
+            'BEGIN:VEVENT',
+            'UID:owner-private',
+            'SUMMARY:Secret meeting',
+            'LOCATION:Paris',
+            'CLASS:PRIVATE',
+            'DTSTART:20130401T090000Z',
+            'DTEND:20130401T100000Z',
+            'END:VEVENT',
+            'END:VCALENDAR'
+        ]) . "\r\n";
+        $this->caldavBackend->createCalendarObject($this->cal['id'], 'owner-private.ics', $privateEvent);
+
+        $response = $this->reportRequest(
+            '/calendars/54b64eadf6d7d8e41d263e0f/calendar1',
+            $this->filterlessQuery()
+        );
+
+        $this->assertEquals(207, $response->status);
+
+        $items = $this->parseMultiStatus($response->getBodyAsString());
+        $href = '/calendars/54b64eadf6d7d8e41d263e0f/calendar1/owner-private.ics';
+
+        $this->assertArrayHasKey($href, $items);
+
+        // The authenticated user owns the calendar, so private details are
+        // returned untouched (no "Busy" sanitization).
+        $vObject = \Sabre\VObject\Reader::read($items[$href]['calendar-data']);
+        $this->assertEquals('Secret meeting', (string) $vObject->VEVENT->SUMMARY);
+        $this->assertEquals('Paris', (string) $vObject->VEVENT->LOCATION);
+    }
+
     function testDepthZeroOnCalendarIsRejected() {
         $response = $this->reportRequest(
             '/calendars/54b64eadf6d7d8e41d263e0f/calendar1',

--- a/tests/CalDAV/CalendarQueryReportTest.php
+++ b/tests/CalDAV/CalendarQueryReportTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace ESN\CalDAV;
+
+require_once ESN_TEST_BASE . '/DAV/ServerMock.php';
+
+/**
+ * Exercises ESN\CalDAV\Plugin::calendarQueryReport, which overrides the stock
+ * Sabre implementation to batch the calendar-data retrieval instead of
+ * reloading every matching object one at a time (linagora/esn-sabre#403).
+ *
+ * @medium
+ */
+class CalendarQueryReportTest extends \ESN\DAV\ServerMock {
+
+    use \Sabre\VObject\PHPUnitAssertions;
+
+    const CALDAV_NS = 'urn:ietf:params:xml:ns:caldav';
+
+    private function reportRequest($uri, $body, $depth = '1', $contentType = 'application/xml') {
+        $request = \Sabre\HTTP\Sapi::createFromServerArray([
+            'REQUEST_METHOD'    => 'REPORT',
+            'HTTP_CONTENT_TYPE' => $contentType,
+            'HTTP_DEPTH'        => $depth,
+            'REQUEST_URI'       => $uri,
+        ]);
+        $request->setBody($body);
+
+        return $this->request($request);
+    }
+
+    /**
+     * Parses a WebDAV multistatus body into a map of href => [calendar-data, etag].
+     */
+    private function parseMultiStatus($body) {
+        $xml = simplexml_load_string($body);
+        $xml->registerXPathNamespace('d', 'DAV:');
+        $xml->registerXPathNamespace('cal', self::CALDAV_NS);
+
+        $result = [];
+        foreach ($xml->xpath('//d:response') as $response) {
+            $response->registerXPathNamespace('d', 'DAV:');
+            $response->registerXPathNamespace('cal', self::CALDAV_NS);
+
+            $href = (string) $response->xpath('d:href')[0];
+            $calendarData = $response->xpath('.//cal:calendar-data');
+            $etag = $response->xpath('.//d:getetag');
+
+            $result[$href] = [
+                'calendar-data' => $calendarData ? (string) $calendarData[0] : null,
+                'etag'          => $etag ? (string) $etag[0] : null,
+            ];
+        }
+
+        return $result;
+    }
+
+    private function filterlessQuery() {
+        return implode("\n", [
+            '<?xml version="1.0" encoding="utf-8" ?>',
+            '<c:calendar-query xmlns:d="DAV:" xmlns:c="' . self::CALDAV_NS . '">',
+            '  <d:prop>',
+            '    <d:getetag/>',
+            '    <c:calendar-data/>',
+            '  </d:prop>',
+            '  <c:filter>',
+            '    <c:comp-filter name="VCALENDAR"/>',
+            '  </c:filter>',
+            '</c:calendar-query>'
+        ]);
+    }
+
+    function testFilterlessReportReturnsEveryObjectWithData() {
+        $response = $this->reportRequest(
+            '/calendars/54b64eadf6d7d8e41d263e0f/calendar1',
+            $this->filterlessQuery()
+        );
+
+        $this->assertEquals(207, $response->status);
+
+        $items = $this->parseMultiStatus($response->getBodyAsString());
+        $hrefs = array_keys($items);
+
+        $this->assertCount(count($this->caldavCalendarObjects), $hrefs);
+
+        foreach (array_keys($this->caldavCalendarObjects) as $uri) {
+            $href = '/calendars/54b64eadf6d7d8e41d263e0f/calendar1/' . $uri;
+            $this->assertArrayHasKey($href, $items);
+            $this->assertNotEmpty($items[$href]['etag']);
+            $this->assertVObjectEqualsVObject(
+                \Sabre\VObject\Reader::read($this->caldavCalendarObjects[$uri]),
+                \Sabre\VObject\Reader::read($items[$href]['calendar-data'])
+            );
+        }
+    }
+
+    function testFilterlessReportAsCalendarJson() {
+        // Request the calendar-data as calendar+json through the report body prop.
+        $body = implode("\n", [
+            '<?xml version="1.0" encoding="utf-8" ?>',
+            '<c:calendar-query xmlns:d="DAV:" xmlns:c="' . self::CALDAV_NS . '">',
+            '  <d:prop>',
+            '    <d:getetag/>',
+            '    <c:calendar-data content-type="application/calendar+json"/>',
+            '  </d:prop>',
+            '  <c:filter>',
+            '    <c:comp-filter name="VCALENDAR"/>',
+            '  </c:filter>',
+            '</c:calendar-query>'
+        ]);
+
+        $response = $this->reportRequest('/calendars/54b64eadf6d7d8e41d263e0f/calendar1', $body);
+
+        $this->assertEquals(207, $response->status);
+
+        $items = $this->parseMultiStatus($response->getBodyAsString());
+        $href = '/calendars/54b64eadf6d7d8e41d263e0f/calendar1/event1.ics';
+
+        $this->assertArrayHasKey($href, $items);
+        $decoded = json_decode($items[$href]['calendar-data'], true);
+        $this->assertIsArray($decoded);
+        $this->assertEquals('vcalendar', $decoded[0]);
+    }
+
+    function testTimeRangeFilterReportReturnsMatchingObjectsOnly() {
+        $body = implode("\n", [
+            '<?xml version="1.0" encoding="utf-8" ?>',
+            '<c:calendar-query xmlns:d="DAV:" xmlns:c="' . self::CALDAV_NS . '">',
+            '  <d:prop>',
+            '    <d:getetag/>',
+            '    <c:calendar-data/>',
+            '  </d:prop>',
+            '  <c:filter>',
+            '    <c:comp-filter name="VCALENDAR">',
+            '      <c:comp-filter name="VEVENT">',
+            '        <c:time-range start="20130101T000000Z" end="20130501T000000Z"/>',
+            '      </c:comp-filter>',
+            '    </c:comp-filter>',
+            '  </c:filter>',
+            '</c:calendar-query>'
+        ]);
+
+        $response = $this->reportRequest('/calendars/54b64eadf6d7d8e41d263e0f/calendar1', $body);
+
+        $this->assertEquals(207, $response->status);
+
+        $items = $this->parseMultiStatus($response->getBodyAsString());
+
+        // Only event2 (2013-04-01) falls inside the requested window.
+        $this->assertCount(1, $items);
+        $this->assertArrayHasKey('/calendars/54b64eadf6d7d8e41d263e0f/calendar1/event2.ics', $items);
+    }
+
+    function testDepthZeroOnCalendarIsRejected() {
+        $response = $this->reportRequest(
+            '/calendars/54b64eadf6d7d8e41d263e0f/calendar1',
+            $this->filterlessQuery(),
+            '0'
+        );
+
+        $this->assertEquals(400, $response->status);
+    }
+}


### PR DESCRIPTION
Closes #403

## Problem

A filter-less `calendar-query` REPORT (the one issued by the `twake-calendar-side-service` reindex task via `CalendarQuery.ofFilters()`) times out for users with a lot of data, while ICS export on the same calendar is fast.

The stock `Sabre\CalDAV\Plugin::calendarQueryReport()` resolves the matching URIs with a single query but then reloads **each object one at a time** through `getPropertiesForPath()`. On a calendar with ~26 500 events that is ~26 500 individual Mongo round-trips + VObject parses in a single request, which blows past every reasonable timeout. The `MongoCursorNotFoundException` seen on the James side is a downstream symptom: the caller's enumeration cursor sits idle waiting for Sabre and gets reaped.

Export is fast because it takes the batched `getPropertiesForPath(..., Depth 1)` path (one query for all objects). The XML `calendar-query` REPORT never got that treatment.

## Fix

Both approaches requested in the issue, in two commits:

1. **`fix(caldav): batch calendar-query REPORT data retrieval`** — override `calendarQueryReport` in `ESN\CalDAV\Plugin` so the Depth: 1 calendar-collection case fetches the calendar data of all matching objects in a **single `getPropertiesForMultiplePaths()` batch**, exactly like `ICSExportPlugin`. This turns N `getCalendarObject` calls into one `$in` query while preserving the standard property pipeline (privacy, custom props, ...). Every other shape (direct object, Depth: 0, expand) is left to the stock implementation.

2. **`perf(caldav): serve filter-less calendar-query REPORT from a single query`** — for the common filter-less case, route straight to the existing `calendarQueryWithAllData()` so `uri` + `calendardata` + `etag` come back in a **single query** and each object is parsed at most once. Falls back to the batched path as soon as a real prop/comp-filter, an expand, a non-Mongo backend or an unsupported requested property is involved. Private-event visibility is preserved by applying the exact same PRIVATE/CONFIDENTIAL sanitization as `PrivateEventPlugin` (delegates get a "Busy" view, owners get full data), reusing the denormalized `classification` field to avoid parsing non-private objects.

Both bring the REPORT in line with export's single-query cost.

## Tests

Added `tests/CalDAV/CalendarQueryReportTest.php` covering:
- filter-less REPORT returns every object with its data + etag (the #403 scenario, exercises the single-query fast path);
- filter-less REPORT as `application/calendar+json`;
- time-range filtered REPORT returns only matching objects (exercises the batched fallback);
- owner sees full data for a `CLASS:PRIVATE` event through the fast path;
- Depth: 0 on a calendar is still rejected.

> Note: the local sandbox has no PHP/Docker, so the PHP suite was not run locally — CI runs it.

---
*Generated automatically*
