### PR TITLE
fix(davacl): check read ACL before PROPFIND & enforce read ACL for JSON reports 

### DIFF
--- a/lib/DAVACL/Plugin.php
+++ b/lib/DAVACL/Plugin.php
@@ -10,7 +10,23 @@ class Plugin extends \ESN\JSON\BasePlugin {
     function initialize(DAV\Server $server) {
         parent::initialize($server);
 
+        $server->on('beforeMethod:PROPFIND', [$this, 'beforePropFind'], 20);
         $server->on('method:PROPFIND', [$this, 'propFind'], 80);
+    }
+
+    public function beforePropFind($request, $response) {
+        $path = $request->getPath();
+        if (!$this->server->tree->nodeExists($path)) {
+            return true;
+        }
+
+        $aclPlugin = $this->server->getPlugin('acl');
+        if ($aclPlugin) {
+            // Sabre's propFind marks unreadable properties as 403 but still emits child hrefs.
+            $aclPlugin->checkPrivileges($path, '{DAV:}read', \Sabre\DAVACL\Plugin::R_PARENT);
+        }
+
+        return true;
     }
 
     public function propFind($request, $response) {

--- a/lib/JSON/Plugin.php
+++ b/lib/JSON/Plugin.php
@@ -257,17 +257,23 @@ class Plugin extends \Sabre\CalDAV\Plugin {
 
         // Handle sync-token based requests
         if (isset($jsonData->{'sync-token'})) {
+            $this->assertCanReadReportPath($path);
             list($code, $body) = $this->handleSyncTokenReport($path, $node, $jsonData);
         } else if ($node instanceof \Sabre\CalDAV\CalendarHome) {
+            $this->assertCanReadReportPath($path);
             list($code, $body) = $this->getCalendarObjectHandler()->getCalendarObjectByUID($path, $node, $jsonData);
         } else if ($node instanceof \Sabre\CalDAV\Subscriptions\Subscription) {
             // Check Subscription before ICalendarObjectContainer since Subscription now implements it
+            $this->assertCanReadReportPath($path);
             list($code, $body) = $this->getSubscriptionHandler()->getCalendarObjectsForSubscription($node, $jsonData);
         } else if ($node instanceof \Sabre\CalDAV\ICalendarObjectContainer) {
+            $this->assertCanReadReportPath($path);
             list($code, $body) = $this->getCalendarObjectHandler()->getCalendarObjects($path, $node, $jsonData);
         } else if ($node instanceof \ESN\CalDAV\CalendarRoot) {
+            $this->assertCanReadReportEventPaths($jsonData);
             list($code, $body) = $this->getCalendarObjectHandler()->getMultipleCalendarObjectsFromPaths($path, $jsonData);
         } else if ($node instanceof \Sabre\CalDAV\ICalendarObject) {
+            $this->assertCanReadReportPath($path);
             list($code, $body) = $this->handleCalendarObjectReport($path, $node, $jsonData);
         } else {
             $code = 200;
@@ -275,6 +281,27 @@ class Plugin extends \Sabre\CalDAV\Plugin {
         }
 
         return $this->send($code, $body);
+    }
+
+    private function assertCanReadReportPath($path) {
+        $aclPlugin = $this->server->getPlugin('acl');
+        if ($aclPlugin) {
+            // JSON REPORT bypasses Sabre's XML REPORT pipeline, so enforce ACL here.
+            $aclPlugin->checkPrivileges($path, '{DAV:}read', \Sabre\DAVACL\Plugin::R_PARENT);
+        }
+    }
+
+    private function assertCanReadReportEventPaths($jsonData) {
+        if (!isset($jsonData->eventPaths)) {
+            return;
+        }
+
+        foreach ($jsonData->eventPaths as $eventPath) {
+            list($calendarPath) = Utils::splitEventPath($eventPath);
+            if ($calendarPath) {
+                $this->assertCanReadReportPath($calendarPath);
+            }
+        }
     }
 
     private function handleSyncTokenReport($path, $node, $jsonData) {

--- a/tests/CardDAV/Subscription/PluginTest.php
+++ b/tests/CardDAV/Subscription/PluginTest.php
@@ -29,6 +29,7 @@ class PluginTest extends \ESN\CardDAV\PluginTestBase {
                 '{http://open-paas.org/contacts}source' => new \Sabre\DAV\Xml\Property\Href('addressbooks/' . $this->userTestId1 . '/book1', false)
             ]
         );
+        $this->authBackend->setPrincipal('principals/users/' . $this->userTestId2);
 
         $request = \Sabre\HTTP\Sapi::createFromServerArray(array(
             'REQUEST_METHOD'    => 'PROPFIND',


### PR DESCRIPTION
Read ACL enforcement added for DAV PROPFIND and JSON REPORT flows.

## Why
Prevent unreadable resources from leaking via PROPFIND child hrefs or JSON REPORT paths that bypass Sabre XML report ACL checks.
