### PR TITLE
fix(utils): fix private team calendar event visibility for members

### DIFF
--- a/lib/Utils/Utils.php
+++ b/lib/Utils/Utils.php
@@ -272,7 +272,19 @@ class Utils {
             return $node->getSourceOwner() !== $userPrincipal;
         }
 
+        if (self::isTeamCalendarSharedInstance($node, $userPrincipal)) {
+            return false;
+        }
+
         return $node->getOwner() !== $userPrincipal;
+    }
+
+    private static function isTeamCalendarSharedInstance($node, $userPrincipal) {
+        if ($userPrincipal === null || !method_exists($node, 'getOwner') || !method_exists($node, 'isSharedInstance')) {
+            return false;
+        }
+
+        return self::isTeamCalendarFromPrincipal($node->getOwner()) && $node->isSharedInstance();
     }
 
     /**

--- a/tests/Utils/UtilsTest.php
+++ b/tests/Utils/UtilsTest.php
@@ -307,6 +307,36 @@ ICS;
         $this->assertFalse(Utils::isHiddenPrivateEvent($vevent, $node, $userPrincipal));
     }
 
+    function testIsHiddenPrivateEventForTeamCalendarMember() {
+        $icalData = join("\r\n", [
+            'BEGIN:VCALENDAR',
+            'VERSION:2.0',
+            'BEGIN:VEVENT',
+            'UID:private-team-calendar-event-test',
+            'DTSTART:20260110T100000Z',
+            'DTEND:20260110T110000Z',
+            'SUMMARY:Secret Team Meeting',
+            'CLASS:PRIVATE',
+            'END:VEVENT',
+            'END:VCALENDAR',
+            ''
+        ]);
+
+        $vcalendar = \Sabre\VObject\Reader::read($icalData);
+        $vevent = $vcalendar->VEVENT;
+
+        $node = new class('principals/team-calendars/team-calendar-id') {
+            private $owner;
+            public function __construct($owner) { $this->owner = $owner; }
+            public function getOwner() { return $this->owner; }
+            public function isSharedInstance() { return true; }
+        };
+
+        $userPrincipal = 'principals/users/member';
+
+        $this->assertFalse(Utils::isHiddenPrivateEvent($vevent, $node, $userPrincipal));
+    }
+
     /**
      * Test that CONFIDENTIAL events are identified as hidden for non-owners
      */


### PR DESCRIPTION
Team calendar events are owned by the team calendar principal, not by the delegated user principal. The previous private/confidential visibility check compared the node owner with the current user, so team calendar members reading their delegated calendar copy were treated as non-owners and received sanitized event details.

