### PR TITLE
issues/417 feat(amqp): add connectedUser field to AMQP payloads

### DIFF
--- a/lib/CalDAV/Schedule/AMQPSchedulePlugin.php
+++ b/lib/CalDAV/Schedule/AMQPSchedulePlugin.php
@@ -145,6 +145,7 @@ class AMQPSchedulePlugin extends Plugin {
         if ($oldMessage !== null) {
             $payload['oldMessage'] = $oldMessage;
         }
+        $payload['connectedUser'] = $this->getConnectedUser();
 
         $this->amqpPublisher->publish(self::TOPIC_LOCAL_DELIVERY, json_encode($payload));
     }
@@ -328,6 +329,7 @@ class AMQPSchedulePlugin extends Plugin {
             if ($this->currentCalendarId !== null) {
                 $delivery['calendarId'] = $this->currentCalendarId;
             }
+            $delivery['connectedUser'] = $this->getConnectedUser();
             $this->amqpPublisher->publish(
                 self::TOPIC_LOCAL_DELIVERY,
                 json_encode($delivery)
@@ -336,5 +338,17 @@ class AMQPSchedulePlugin extends Plugin {
         $this->pendingDeliveries  = [];
         $this->currentOldMessage  = null;
         $this->currentCalendarId  = null;
+    }
+
+    /**
+     * Returns the principal URI of the currently authenticated user, i.e. who
+     * actually performed the action, so consumers can audit who did what (and
+     * not just deduce the resource owner). Returns null when no user is
+     * authenticated.
+     */
+    private function getConnectedUser() {
+        $authPlugin = $this->server->getPlugin('auth');
+
+        return $authPlugin ? $authPlugin->getCurrentPrincipal() : null;
     }
 }

--- a/lib/Publisher/RealTimePlugin.php
+++ b/lib/Publisher/RealTimePlugin.php
@@ -36,10 +36,32 @@ abstract class RealTimePlugin extends ServerPlugin {
         return $this->messages;
     }
 
+    /**
+     * Returns the principal URI of the currently authenticated user, i.e. who
+     * actually performed the action that triggers this realtime message. This
+     * may differ from the resource owner (delegation, admin impersonation,
+     * technical token), which is exactly why it is worth reporting for
+     * auditability. Returns null when no user is authenticated.
+     */
+    protected function getConnectedUser() {
+        if (!$this->server) {
+            return null;
+        }
+
+        $authPlugin = $this->server->getPlugin('auth');
+
+        return $authPlugin ? $authPlugin->getCurrentPrincipal() : null;
+    }
+
     public function publishMessages() {
+        $connectedUser = $this->getConnectedUser();
+
         foreach($this->messages as $message) {
             try {
                 $message['data'] = $this->buildData($message['data']);
+                if (is_array($message['data'])) {
+                    $message['data']['connectedUser'] = $connectedUser;
+                }
                 $this->client->publish($message['topic'], json_encode($message['data']));
             } catch (\Exception $e) {
                 // Be lenient: a malformed event (e.g. an invalid RRULE UNTIL value) that cannot be

--- a/tests/Publisher/CalDAV/CalendarRealTimePluginTest.php
+++ b/tests/Publisher/CalDAV/CalendarRealTimePluginTest.php
@@ -7,6 +7,7 @@ require_once ESN_TEST_BASE . '/CalDAV/MockUtils.php';
 class CalendarRealTimePluginTest extends \PHPUnit\Framework\TestCase {
 
     const PATH = "calendars/123123/uid.ics";
+    const CONNECTED_USER = 'principals/users/connectedUser';
     protected $eventEmitter;
     protected $plugin;
     protected $publisher;
@@ -30,8 +31,13 @@ class CalendarRealTimePluginTest extends \PHPUnit\Framework\TestCase {
         $this->server->tree->expects($this->any())->method('nodeExists')
             ->with('/'.self::PATH)
             ->willReturn(true);
+        $authPlugin = $this->createMock(\Sabre\DAV\Auth\Plugin::class);
+        $authPlugin->method('getCurrentPrincipal')->willReturn(self::CONNECTED_USER);
+        $sharingPlugin = $this->createMock(\ESN\DAV\Sharing\Plugin::class);
         $this->server->expects($this->any())->method('getPlugin')
-            ->willReturn($this->createMock(\ESN\DAV\Sharing\Plugin::class));
+            ->willReturnCallback(function($name) use ($authPlugin, $sharingPlugin) {
+                return $name === 'auth' ? $authPlugin : $sharingPlugin;
+            });
 
         $nodeMock = new class extends \Sabre\CalDAV\Calendar {
             public function __construct() {}
@@ -59,6 +65,13 @@ class CalendarRealTimePluginTest extends \PHPUnit\Framework\TestCase {
         $this->server->tree->expects($this->any())->method('getNodeForPath')
             ->with('/'.self::PATH)
             ->willReturn($nodeMock);
+    }
+
+    private function connectedUserAuthPlugin() {
+        $authPlugin = $this->createMock(\Sabre\DAV\Auth\Plugin::class);
+        $authPlugin->method('getCurrentPrincipal')->willReturn(self::CONNECTED_USER);
+
+        return $authPlugin;
     }
 
     function testGetCalendarProps() {
@@ -108,21 +121,24 @@ class CalendarRealTimePluginTest extends \PHPUnit\Framework\TestCase {
             'calendarPath' => '/calendars/1/uri1',
             'calendarProps' => [
                 'public_right' => 'privilege'
-            ]
+            ],
+            'connectedUser' => self::CONNECTED_USER
         ];
 
         $secondfirstExpectedData = [
             'calendarPath' => '/calendars/2/uri2',
             'calendarProps' => [
                 'public_right' => 'privilege'
-            ]
+            ],
+            'connectedUser' => self::CONNECTED_USER
         ];
 
         $thirdExpectedData = [
             'calendarPath' => '/calendars/3/uri3',
             'calendarProps' => [
                 'public_right' => 'privilege'
-            ]
+            ],
+            'connectedUser' => self::CONNECTED_USER
         ];
 
         $expectedCalls = [
@@ -150,7 +166,8 @@ class CalendarRealTimePluginTest extends \PHPUnit\Framework\TestCase {
             'calendarPath' => '/calendars/3/uri3',
             'calendarProps' => [
                 'public_right' => 'privilege'
-            ]
+            ],
+            'connectedUser' => self::CONNECTED_USER
         ];
 
         $this->publisher
@@ -240,7 +257,9 @@ class CalendarRealTimePluginTest extends \PHPUnit\Framework\TestCase {
         $sharingPlugin = $this->createMock(\ESN\DAV\Sharing\Plugin::class);
         $sharingPlugin->method('accessToRightRse')->willReturn('dav:read');
         $server = $this->createMock(\Sabre\DAV\Server::class);
-        $server->method('getPlugin')->with('sharing')->willReturn($sharingPlugin);
+        $server->method('getPlugin')->willReturnCallback(function($name) use ($sharingPlugin) {
+            return $name === 'auth' ? $this->connectedUserAuthPlugin() : $sharingPlugin;
+        });
         $this->plugin->initialize($server);
 
         $calendarInstances = [
@@ -256,11 +275,13 @@ class CalendarRealTimePluginTest extends \PHPUnit\Framework\TestCase {
         $expectedCalls = [
             ['calendar:calendar:updated', json_encode([
                 'calendarPath' => '/calendars/alice/uid-alice',
-                'calendarProps' => ['access' => 'dav:read']
+                'calendarProps' => ['access' => 'dav:read'],
+                'connectedUser' => self::CONNECTED_USER
             ])],
             ['calendar:calendar:updated', json_encode([
                 'calendarPath' => '/calendars/bob/bobcal',
-                'calendarProps' => ['delegation_updated' => true]
+                'calendarProps' => ['delegation_updated' => true],
+                'connectedUser' => self::CONNECTED_USER
             ])]
         ];
         $callIndex = 0;
@@ -282,7 +303,9 @@ class CalendarRealTimePluginTest extends \PHPUnit\Framework\TestCase {
         $sharingPlugin = $this->createMock(\ESN\DAV\Sharing\Plugin::class);
         $sharingPlugin->method('accessToRightRse')->willReturn('dav:read');
         $server = $this->createMock(\Sabre\DAV\Server::class);
-        $server->method('getPlugin')->with('sharing')->willReturn($sharingPlugin);
+        $server->method('getPlugin')->willReturnCallback(function($name) use ($sharingPlugin) {
+            return $name === 'auth' ? $this->connectedUserAuthPlugin() : $sharingPlugin;
+        });
         $this->plugin->initialize($server);
 
         $calendarInstances = [
@@ -304,15 +327,18 @@ class CalendarRealTimePluginTest extends \PHPUnit\Framework\TestCase {
         $expectedCalls = [
             ['calendar:calendar:updated', json_encode([
                 'calendarPath' => '/calendars/alice/uid-alice',
-                'calendarProps' => ['access' => 'dav:read']
+                'calendarProps' => ['access' => 'dav:read'],
+                'connectedUser' => self::CONNECTED_USER
             ])],
             ['calendar:calendar:updated', json_encode([
                 'calendarPath' => '/calendars/bob/bobcal',
-                'calendarProps' => ['delegation_updated' => true]
+                'calendarProps' => ['delegation_updated' => true],
+                'connectedUser' => self::CONNECTED_USER
             ])],
             ['calendar:calendar:updated', json_encode([
                 'calendarPath' => '/calendars/cedric/uid-cedric',
-                'calendarProps' => ['access' => 'dav:read']
+                'calendarProps' => ['access' => 'dav:read'],
+                'connectedUser' => self::CONNECTED_USER
             ])]
         ];
         $callIndex = 0;
@@ -333,7 +359,9 @@ class CalendarRealTimePluginTest extends \PHPUnit\Framework\TestCase {
         // Given: a sharee delete with a source calendar path.
         $sharingPlugin = $this->createMock(\ESN\DAV\Sharing\Plugin::class);
         $server = $this->createMock(\Sabre\DAV\Server::class);
-        $server->method('getPlugin')->with('sharing')->willReturn($sharingPlugin);
+        $server->method('getPlugin')->willReturnCallback(function($name) use ($sharingPlugin) {
+            return $name === 'auth' ? $this->connectedUserAuthPlugin() : $sharingPlugin;
+        });
         $this->plugin->initialize($server);
 
         $calendarInstances = [
@@ -349,11 +377,13 @@ class CalendarRealTimePluginTest extends \PHPUnit\Framework\TestCase {
         $expectedCalls = [
             ['calendar:calendar:deleted', json_encode([
                 'calendarPath' => '/calendars/alice/uid-alice',
-                'calendarProps' => null
+                'calendarProps' => null,
+                'connectedUser' => self::CONNECTED_USER
             ])],
             ['calendar:calendar:updated', json_encode([
                 'calendarPath' => '/calendars/bob/bobcal',
-                'calendarProps' => ['delegation_updated' => true]
+                'calendarProps' => ['delegation_updated' => true],
+                'connectedUser' => self::CONNECTED_USER
             ])]
         ];
         $callIndex = 0;

--- a/tests/Publisher/CalDAV/SubscriptionRealTimePluginTest.php
+++ b/tests/Publisher/CalDAV/SubscriptionRealTimePluginTest.php
@@ -35,7 +35,7 @@ class SubscriptionRealTimePluginTest extends \PHPUnit\Framework\TestCase {
         $this->publisher
             ->expects($this->once())
             ->method('publish')
-            ->with('calendar:subscription:created', json_encode(["calendarPath" => self::PATH, "calendarSourcePath" => null]));
+            ->with('calendar:subscription:created', json_encode(["calendarPath" => self::PATH, "calendarSourcePath" => null, "connectedUser" => null]));
         $this->plugin->subscriptionCreated(self::PATH);
     }
 
@@ -44,7 +44,7 @@ class SubscriptionRealTimePluginTest extends \PHPUnit\Framework\TestCase {
         $this->publisher
             ->expects($this->once())
             ->method('publish')
-            ->with('calendar:subscription:deleted', json_encode(["calendarPath" => self::PATH, "calendarSourcePath" => $sourcePath]));
+            ->with('calendar:subscription:deleted', json_encode(["calendarPath" => self::PATH, "calendarSourcePath" => $sourcePath, "connectedUser" => null]));
         $this->plugin->subscriptionDeleted(self::PATH, $sourcePath);
     }
 
@@ -52,7 +52,7 @@ class SubscriptionRealTimePluginTest extends \PHPUnit\Framework\TestCase {
         $this->publisher
             ->expects($this->once())
             ->method('publish')
-            ->with('calendar:subscription:updated', json_encode(["calendarPath" => self::PATH, "calendarSourcePath" => null]));
+            ->with('calendar:subscription:updated', json_encode(["calendarPath" => self::PATH, "calendarSourcePath" => null, "connectedUser" => null]));
         $this->plugin->subscriptionUpdated(self::PATH);
     }
 }

--- a/tests/Publisher/RealTimePluginTest.php
+++ b/tests/Publisher/RealTimePluginTest.php
@@ -52,4 +52,36 @@ class RealTimePluginTest extends \PHPUnit\Framework\TestCase {
 
         $this->plugin->publishMessages();
     }
+
+    function testPublishMessagesInjectsConnectedUser() {
+        $authPlugin = $this->createMock(\Sabre\DAV\Auth\Plugin::class);
+        $authPlugin->method('getCurrentPrincipal')->willReturn('principals/users/alice');
+        $server = $this->createMock(\Sabre\DAV\Server::class);
+        $server->method('getPlugin')->with('auth')->willReturn($authPlugin);
+        $this->plugin->initialize($server);
+
+        $data = ['foo' => 'bar'];
+        $this->plugin->expects($this->any())->method('buildData')->with($data)->willReturn($data);
+
+        $this->publisher->expects($this->once())->method('publish')
+            ->with('topic', json_encode(['foo' => 'bar', 'connectedUser' => 'principals/users/alice']));
+
+        $this->plugin->createMessage('topic', $data);
+        $this->plugin->publishMessages();
+    }
+
+    function testPublishMessagesInjectsNullConnectedUserWhenNotAuthenticated() {
+        $server = $this->createMock(\Sabre\DAV\Server::class);
+        $server->method('getPlugin')->with('auth')->willReturn(null);
+        $this->plugin->initialize($server);
+
+        $data = ['foo' => 'bar'];
+        $this->plugin->expects($this->any())->method('buildData')->with($data)->willReturn($data);
+
+        $this->publisher->expects($this->once())->method('publish')
+            ->with('topic', json_encode(['foo' => 'bar', 'connectedUser' => null]));
+
+        $this->plugin->createMessage('topic', $data);
+        $this->plugin->publishMessages();
+    }
 }


### PR DESCRIPTION
Closes #417

## Why

Consumers on RabbitMQ can currently deduce the resource *owner* from AMQP payloads, but not *who actually performed the action*. This makes auditability ("who did what") impossible when the actor differs from the owner — e.g. delegation, admin impersonation, or a technical token.

## What

Adds a `connectedUser` field to every AMQP/realtime payload. Its value is the authenticated principal URI (from the auth plugin `getCurrentPrincipal()`), or `null` when no user is authenticated.

The field is injected in two central places so it covers all payloads:

- **`RealTimePlugin::publishMessages()`** — a single injection point covering all realtime publishers: event, calendar, contact, address book and subscription plugins (CalDAV & CardDAV). Non-array payloads are left untouched.
- **`AMQPSchedulePlugin`** — the iTip `localDelivery` and `COUNTER` payloads, which publish directly to AMQP.

## Tests

- New unit tests in `RealTimePluginTest` verifying the field is populated with the connected principal and falls back to `null` when unauthenticated.
- Existing publisher tests updated to expect the new field.

---
*Generated automatically*
