### PR TITLE
issues/425 feat(auth): auto-provision users upon DAV request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### New Features
+
+ - ISSUE-425 Auto-provision users upon a DAV request — when an LDAP or impersonated user authenticates successfully but has no entry in the `users` collection yet, the entry is created on the fly (following the twake-calendar-side-service document format) instead of returning a `401`. Gated by the `AUTO_PROVISION` env var (default `true`). Needed upon migrations (#425)
+
 ### Bug Fixes
 
  - ISSUE-404 Fix duplicated `DAV`/`X-Sabre-Version` headers in DAV responses — the nginx capability headers are now only emitted for the OPTIONS short-circuit, letting Sabre emit them once (with consistent casing) for proxied responses (#404)

--- a/doc/CONFIGURE.md
+++ b/doc/CONFIGURE.md
@@ -42,6 +42,14 @@ Feature flag to enable or disable admin impersonation.
    This flag allows disabling admin impersonation entirely on public Sabre deployments
    to prevent impersonation over the internet.
 
+Feature flag to auto-provision users upon a DAV request.
+ - AUTO_PROVISION
+
+   - unset or `true`: when an LDAP or impersonated user authenticates successfully but has no entry in the `users` collection yet, the entry is created on the fly instead of returning a `401` (default)
+   - `false`: keep the legacy behaviour and return `401` when the user does not exist
+
+   The domain part of the user's email must match an existing domain, otherwise the user cannot be provisioned. Needed upon migrations.
+
 Feature flag to restrict DAV principal discovery.
  - PRINCIPAL_PRIVACY
 

--- a/lib/DAV/Auth/Backend/Esn.php
+++ b/lib/DAV/Auth/Backend/Esn.php
@@ -237,12 +237,67 @@ class Esn implements \Sabre\DAV\Auth\Backend\BackendInterface {
      * Needed upon migrations: instead of returning a 401 for a legitimate LDAP
      * or impersonated user that is not yet in the `users` collection, the entry
      * is created on the fly. Gated by the AUTO_PROVISION env var (default true).
+     *
+     * The user is only provisioned when it actually exists in the LDAP
+     * directory, and its firstname/lastname are taken from the LDAP entry so
+     * both services share the same content.
      */
     private function autoProvisionUser(string $email): ?AuthTenant {
         if (!$this->autoProvisionEnabled()) {
             return null;
         }
-        return $this->principalBackend->provisionUser($email);
+
+        $entry = $this->findLdapEntryByEmail($email);
+        if ($entry === null) {
+            error_log("autoProvisionUser: no LDAP entry for '$email', skipping auto-provision");
+            return null;
+        }
+
+        $firstname = $entry['givenname'][0] ?? '';
+        $lastname = $entry['sn'][0] ?? '';
+
+        return $this->principalBackend->provisionUser($email, $firstname, $lastname);
+    }
+
+    /**
+     * Look up an LDAP entry by mail, returning the raw entry or null when absent.
+     *
+     * Backs auto-provisioning: it lets us both confirm the user exists in the
+     * LDAP directory and read its content (firstname, lastname).
+     */
+    private function findLdapEntryByEmail(string $email): ?array {
+        $ldapCon = ldap_connect(LDAP_SERVER);
+        if (!$ldapCon) {
+            error_log('findLdapEntryByEmail: unable to connect to LDAP server');
+            return null;
+        }
+        try {
+            ldap_set_option($ldapCon, LDAP_OPT_PROTOCOL_VERSION, 3);
+            ldap_set_option($ldapCon, LDAP_OPT_REFERRALS, 0);
+
+            $ldapBind = ldap_bind($ldapCon, LDAP_ADMIN_DN, LDAP_ADMIN_PASSWORD);
+            if (!$ldapBind) {
+                $code = ldap_errno($ldapCon);
+                $msg  = ldap_error($ldapCon);
+                error_log("findLdapEntryByEmail: bad admin credentials. LDAP bind failed: [$code] '$msg'");
+                return null;
+            }
+
+            $safeEmail = ldap_escape($email, '', 0);
+            if (LDAP_FILTER != null) {
+                $searchResult = ldap_search($ldapCon, LDAP_BASE, "(& (mail=$safeEmail) " . LDAP_FILTER . ')');
+            } else {
+                $searchResult = ldap_search($ldapCon, LDAP_BASE, "(mail=$safeEmail)");
+            }
+            $entries = ldap_get_entries($ldapCon, $searchResult);
+        } finally {
+            ldap_close($ldapCon);
+        }
+
+        if ($entries['count'] == 0) {
+            return null;
+        }
+        return $entries[0];
     }
 
     private function autoProvisionEnabled(): bool {

--- a/lib/DAV/Auth/Backend/Esn.php
+++ b/lib/DAV/Auth/Backend/Esn.php
@@ -134,6 +134,10 @@ class Esn implements \Sabre\DAV\Auth\Backend\BackendInterface {
         if($tenant)
             return $tenant;
 
+        $tenant = $this->autoProvisionUser($impersonationResult);
+        if($tenant)
+            return $tenant;
+
         error_log("User not found for email: $impersonationResult");
         throw new AuthException("User not found");
     }
@@ -218,10 +222,35 @@ class Esn implements \Sabre\DAV\Auth\Backend\BackendInterface {
 
         $tenant = $this->principalBackend->getAuthTenantByEmail($mail);
         if (!$tenant) {
+            $tenant = $this->autoProvisionUser($mail);
+        }
+        if (!$tenant) {
             error_log("User not found for email: $mail");
             throw new  AuthException("User not found");
         }
         return $tenant;
+    }
+
+    /**
+     * Auto-provision a user upon a DAV request when it does not yet exist.
+     *
+     * Needed upon migrations: instead of returning a 401 for a legitimate LDAP
+     * or impersonated user that is not yet in the `users` collection, the entry
+     * is created on the fly. Gated by the AUTO_PROVISION env var (default true).
+     */
+    private function autoProvisionUser(string $email): ?AuthTenant {
+        if (!$this->autoProvisionEnabled()) {
+            return null;
+        }
+        return $this->principalBackend->provisionUser($email);
+    }
+
+    private function autoProvisionEnabled(): bool {
+        $env = getenv('AUTO_PROVISION');
+        if ($env === false || $env === '') {
+            return true;
+        }
+        return filter_var($env, FILTER_VALIDATE_BOOLEAN);
     }
 
     private function impersonationEnabled(): bool {

--- a/lib/DAVACL/PrincipalBackend/Mongo.php
+++ b/lib/DAVACL/PrincipalBackend/Mongo.php
@@ -301,6 +301,62 @@ class Mongo extends \Sabre\DAVACL\PrincipalBackend\AbstractBackend {
         return new AuthTenant($user['_id'], (string) $domainObjectId, $tenantType);
     }
 
+    /**
+     * Auto-provision a user in the `users` collection for the given email.
+     *
+     * The domain part of the email must match an existing domain, otherwise the
+     * user cannot be attached to a tenant and null is returned. The created
+     * document follows the format used by twake-calendar-side-service so that
+     * both services share the same data model.
+     */
+    function provisionUser(string $email, ?TenantType $tenantType = null): ?AuthTenant {
+        $tenantType = $tenantType ?? TenantType::User;
+
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            return null;
+        }
+
+        $email = strtolower($email);
+        $domainName = explode('@', $email)[1];
+
+        $domain = $this->db->domains->findOne(
+            [ 'name' => $domainName ],
+            [ 'projection' => [ '_id' => 1 ] ]
+        );
+        if (!$domain) {
+            error_log("provisionUser: no domain '$domainName' found, cannot auto-provision '$email'");
+            return null;
+        }
+        $domainObjectId = $domain['_id'];
+
+        $userId = new \MongoDB\BSON\ObjectId();
+        $document = [
+            '_id' => $userId,
+            'firstname' => '',
+            'lastname' => '',
+            'firstnames' => [],
+            'password' => 'secret',
+            // not part of the OpenPaaS data model but helps solve concurrency
+            'email' => $email,
+            'domains' => [
+                [ 'domain_id' => $domainObjectId ]
+            ],
+            'accounts' => [
+                [ 'type' => 'email', 'emails' => [ $email ] ]
+            ]
+        ];
+
+        try {
+            $this->db->users->insertOne($document);
+        } catch (\MongoDB\Driver\Exception\BulkWriteException $e) {
+            // A concurrent request likely provisioned the same user; re-read it.
+            error_log("provisionUser: concurrent insert for '$email', re-reading: " . $e->getMessage());
+            return $this->getAuthTenantByEmail($email, $tenantType);
+        }
+
+        return new AuthTenant($userId, (string) $domainObjectId, $tenantType);
+    }
+
     function getAuthTenantByResourceEmail($email, ?TenantType $tenantType = null) {
         $tenantType = $tenantType ?? TenantType::Resources;
 

--- a/lib/DAVACL/PrincipalBackend/Mongo.php
+++ b/lib/DAVACL/PrincipalBackend/Mongo.php
@@ -304,12 +304,14 @@ class Mongo extends \Sabre\DAVACL\PrincipalBackend\AbstractBackend {
     /**
      * Auto-provision a user in the `users` collection for the given email.
      *
-     * The domain part of the email must match an existing domain, otherwise the
-     * user cannot be attached to a tenant and null is returned. The created
-     * document follows the format used by twake-calendar-side-service so that
-     * both services share the same data model.
+     * The firstname and lastname are taken from the LDAP entry that backs the
+     * user (see the auth backend). The domain part of the email must match an
+     * existing domain, otherwise the user cannot be attached to a tenant and
+     * null is returned. The created document follows the format used by
+     * twake-calendar-side-service so that both services share the same data
+     * model.
      */
-    function provisionUser(string $email, ?TenantType $tenantType = null): ?AuthTenant {
+    function provisionUser(string $email, string $firstname = '', string $lastname = '', ?TenantType $tenantType = null): ?AuthTenant {
         $tenantType = $tenantType ?? TenantType::User;
 
         if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
@@ -332,8 +334,8 @@ class Mongo extends \Sabre\DAVACL\PrincipalBackend\AbstractBackend {
         $userId = new \MongoDB\BSON\ObjectId();
         $document = [
             '_id' => $userId,
-            'firstname' => '',
-            'lastname' => '',
+            'firstname' => $firstname,
+            'lastname' => $lastname,
             'firstnames' => [],
             'password' => 'secret',
             // not part of the OpenPaaS data model but helps solve concurrency

--- a/lib/DAVACL/PrincipalBackend/PrivatePrincipalBackend.php
+++ b/lib/DAVACL/PrincipalBackend/PrivatePrincipalBackend.php
@@ -59,6 +59,10 @@ class PrivatePrincipalBackend extends AbstractBackend {
         return $this->principalBackend->getAuthTenantByResourceEmail($email, $tenantType ?? TenantType::Resources);
     }
 
+    function provisionUser(string $email, ?TenantType $tenantType = null): ?AuthTenant {
+        return $this->principalBackend->provisionUser($email, $tenantType ?? TenantType::User);
+    }
+
     function getAuthTenantByTeamCalendarEmail($email, ?TenantType $tenantType = null): ?AuthTenant {
         return $this->principalBackend->getAuthTenantByTeamCalendarEmail($email, $tenantType ?? TenantType::TeamCalendars);
     }

--- a/lib/DAVACL/PrincipalBackend/PrivatePrincipalBackend.php
+++ b/lib/DAVACL/PrincipalBackend/PrivatePrincipalBackend.php
@@ -59,8 +59,8 @@ class PrivatePrincipalBackend extends AbstractBackend {
         return $this->principalBackend->getAuthTenantByResourceEmail($email, $tenantType ?? TenantType::Resources);
     }
 
-    function provisionUser(string $email, ?TenantType $tenantType = null): ?AuthTenant {
-        return $this->principalBackend->provisionUser($email, $tenantType ?? TenantType::User);
+    function provisionUser(string $email, string $firstname = '', string $lastname = '', ?TenantType $tenantType = null): ?AuthTenant {
+        return $this->principalBackend->provisionUser($email, $firstname, $lastname, $tenantType ?? TenantType::User);
     }
 
     function getAuthTenantByTeamCalendarEmail($email, ?TenantType $tenantType = null): ?AuthTenant {

--- a/tests/DAV/Auth/Backend/EsnTest.php
+++ b/tests/DAV/Auth/Backend/EsnTest.php
@@ -5,6 +5,7 @@ namespace ESN\DAV\Auth\Backend;
 $GLOBALS['__ldap_bind_behavior'] = 'default';
 $GLOBALS['__ldap_mock_enabled'] = false;
 $GLOBALS['__ldap_mock_email'] = 'johndoe@linagora.com';
+$GLOBALS['__ldap_mock_entries_empty'] = false;
 
 function ldap_connect($host) {
     if ($GLOBALS['__ldap_mock_enabled']) {
@@ -43,11 +44,16 @@ function ldap_search($conn, $base, $filter) {
 
 function ldap_get_entries($conn, $result) {
     if ($GLOBALS['__ldap_mock_enabled']) {
+        if ($GLOBALS['__ldap_mock_entries_empty']) {
+            return [ 'count' => 0 ];
+        }
         return [
             'count' => 1,
             0 => [
                 'mail' => [$GLOBALS['__ldap_mock_email'], 'count' => 1],
-                'count' => 1
+                'givenname' => ['John', 'count' => 1],
+                'sn' => ['Doe', 'count' => 1],
+                'count' => 3
             ]
         ];
     }
@@ -566,6 +572,9 @@ class EsnTest extends \PHPUnit\Framework\TestCase {
         $this->assertEquals('principals/users/' . (string) $created['_id'], $msg);
         $this->assertEquals('johndoe@linagora.com', $created['email']);
         $this->assertEquals($domainId, $created['domains'][0]['domain_id']);
+        // firstname/lastname are backed by the LDAP entry content.
+        $this->assertEquals('John', $created['firstname']);
+        $this->assertEquals('Doe', $created['lastname']);
 
         $GLOBALS['__ldap_mock_enabled'] = false;
     }
@@ -628,6 +637,8 @@ class EsnTest extends \PHPUnit\Framework\TestCase {
     function testAutoProvisionOnImpersonationWhenUserMissing() {
         putenv('SABRE_IMPERSONATION_ENABLED=true');
         putenv('AUTO_PROVISION=true');
+        // The impersonated user must exist in the LDAP directory to be provisioned.
+        $GLOBALS['__ldap_mock_enabled'] = true;
 
         $esnauth = new EsnMock('http://localhost:8080/');
 
@@ -655,7 +666,46 @@ class EsnTest extends \PHPUnit\Framework\TestCase {
         $this->assertNotNull($created);
         $this->assertEquals('principals/users/' . (string) $created['_id'], $msg);
         $this->assertEquals($domainId, $created['domains'][0]['domain_id']);
+        $this->assertEquals('John', $created['firstname']);
+        $this->assertEquals('Doe', $created['lastname']);
 
+        $GLOBALS['__ldap_mock_enabled'] = false;
+        putenv('AUTO_PROVISION');
+        putenv('SABRE_IMPERSONATION_ENABLED=false');
+    }
+
+    function testAutoProvisionSkippedWhenUserNotInLdap() {
+        putenv('SABRE_IMPERSONATION_ENABLED=true');
+        putenv('AUTO_PROVISION=true');
+        // The LDAP directory returns no entry: the user must not be provisioned.
+        $GLOBALS['__ldap_mock_enabled'] = true;
+        $GLOBALS['__ldap_mock_entries_empty'] = true;
+
+        $esnauth = new EsnMock('http://localhost:8080/');
+
+        $esnDb = $esnauth->getDb();
+        $domainId = new \MongoDB\BSON\ObjectId('888888888888888888888888');
+        $esnDb->domains->insertOne([
+            '_id' => $domainId,
+            'name' => 'example.com',
+            'administrators' => []
+        ]);
+
+        $request = \Sabre\HTTP\Sapi::createFromServerArray([
+            'PHP_AUTH_USER' => 'admin&ghost@example.com',
+            'PHP_AUTH_PW'   => 'test-admin-password',
+            'REQUEST_URI'   => '/',
+            'REQUEST_METHOD'=> 'GET',
+        ]);
+        $response = new \Sabre\HTTP\Response();
+
+        [$rv, $msg] = $esnauth->check($request, $response);
+
+        $this->assertFalse($rv);
+        $this->assertNull($esnDb->users->findOne([ 'accounts.emails' => 'ghost@example.com' ]));
+
+        $GLOBALS['__ldap_mock_entries_empty'] = false;
+        $GLOBALS['__ldap_mock_enabled'] = false;
         putenv('AUTO_PROVISION');
         putenv('SABRE_IMPERSONATION_ENABLED=false');
     }

--- a/tests/DAV/Auth/Backend/EsnTest.php
+++ b/tests/DAV/Auth/Backend/EsnTest.php
@@ -534,6 +534,132 @@ class EsnTest extends \PHPUnit\Framework\TestCase {
         $this->assertFalse($rv);
     }
 
+    function testAutoProvisionOnLdapWhenUserMissing() {
+        $GLOBALS['__ldap_mock_enabled'] = true;
+        putenv('AUTO_PROVISION');
+
+        $esnauth = new EsnMock('http://localhost:8080/');
+
+        // The domain exists but the user does not yet: it must be auto-provisioned.
+        $esnDb = $esnauth->getDb();
+        $domainId = new \MongoDB\BSON\ObjectId('098765432109876543210987');
+        $esnDb->domains->insertOne([
+            '_id' => $domainId,
+            'name' => 'linagora.com',
+            'administrators' => []
+        ]);
+
+        $request = \Sabre\HTTP\Sapi::createFromServerArray(array(
+            'PHP_AUTH_USER' => 'username',
+            'PHP_AUTH_PW' => 'password',
+            'REQUEST_URI' => '/',
+            'REQUEST_METHOD' => 'GET',
+        ));
+        $response = new \Sabre\HTTP\Response();
+
+        list($rv, $msg) = $esnauth->check($request, $response);
+
+        $this->assertTrue($rv);
+
+        $created = $esnDb->users->findOne([ 'accounts.emails' => 'johndoe@linagora.com' ]);
+        $this->assertNotNull($created);
+        $this->assertEquals('principals/users/' . (string) $created['_id'], $msg);
+        $this->assertEquals('johndoe@linagora.com', $created['email']);
+        $this->assertEquals($domainId, $created['domains'][0]['domain_id']);
+
+        $GLOBALS['__ldap_mock_enabled'] = false;
+    }
+
+    function testAutoProvisionDisabledReturns401() {
+        $GLOBALS['__ldap_mock_enabled'] = true;
+        putenv('AUTO_PROVISION=false');
+
+        $esnauth = new EsnMock('http://localhost:8080/');
+
+        $esnDb = $esnauth->getDb();
+        $domainId = new \MongoDB\BSON\ObjectId('098765432109876543210987');
+        $esnDb->domains->insertOne([
+            '_id' => $domainId,
+            'name' => 'linagora.com',
+            'administrators' => []
+        ]);
+
+        $request = \Sabre\HTTP\Sapi::createFromServerArray(array(
+            'PHP_AUTH_USER' => 'username',
+            'PHP_AUTH_PW' => 'password',
+            'REQUEST_URI' => '/',
+            'REQUEST_METHOD' => 'GET',
+        ));
+        $response = new \Sabre\HTTP\Response();
+
+        list($rv, $msg) = $esnauth->check($request, $response);
+
+        $this->assertFalse($rv);
+        $this->assertNull($esnDb->users->findOne([ 'accounts.emails' => 'johndoe@linagora.com' ]));
+
+        putenv('AUTO_PROVISION');
+        $GLOBALS['__ldap_mock_enabled'] = false;
+    }
+
+    function testAutoProvisionSkippedWhenDomainMissing() {
+        $GLOBALS['__ldap_mock_enabled'] = true;
+        putenv('AUTO_PROVISION=true');
+
+        $esnauth = new EsnMock('http://localhost:8080/');
+        // No domain inserted: the user cannot be attached to a tenant.
+
+        $request = \Sabre\HTTP\Sapi::createFromServerArray(array(
+            'PHP_AUTH_USER' => 'username',
+            'PHP_AUTH_PW' => 'password',
+            'REQUEST_URI' => '/',
+            'REQUEST_METHOD' => 'GET',
+        ));
+        $response = new \Sabre\HTTP\Response();
+
+        list($rv, $msg) = $esnauth->check($request, $response);
+
+        $this->assertFalse($rv);
+        $this->assertNull($esnauth->getDb()->users->findOne([ 'accounts.emails' => 'johndoe@linagora.com' ]));
+
+        putenv('AUTO_PROVISION');
+        $GLOBALS['__ldap_mock_enabled'] = false;
+    }
+
+    function testAutoProvisionOnImpersonationWhenUserMissing() {
+        putenv('SABRE_IMPERSONATION_ENABLED=true');
+        putenv('AUTO_PROVISION=true');
+
+        $esnauth = new EsnMock('http://localhost:8080/');
+
+        $esnDb = $esnauth->getDb();
+        $domainId = new \MongoDB\BSON\ObjectId('888888888888888888888888');
+        $esnDb->domains->insertOne([
+            '_id' => $domainId,
+            'name' => 'example.com',
+            'administrators' => []
+        ]);
+
+        $request = \Sabre\HTTP\Sapi::createFromServerArray([
+            'PHP_AUTH_USER' => 'admin&newcomer@example.com',
+            'PHP_AUTH_PW'   => 'test-admin-password',
+            'REQUEST_URI'   => '/',
+            'REQUEST_METHOD'=> 'GET',
+        ]);
+        $response = new \Sabre\HTTP\Response();
+
+        [$rv, $msg] = $esnauth->check($request, $response);
+
+        $this->assertTrue($rv);
+
+        $created = $esnDb->users->findOne([ 'accounts.emails' => 'newcomer@example.com' ]);
+        $this->assertNotNull($created);
+        $this->assertEquals('principals/users/' . (string) $created['_id'], $msg);
+        $this->assertEquals($domainId, $created['domains'][0]['domain_id']);
+
+        putenv('AUTO_PROVISION');
+        putenv('SABRE_IMPERSONATION_ENABLED=false');
+    }
+
     function testAdminImpersonationDisabled() {
         putenv('SABRE_IMPERSONATION_ENABLED=false');
 

--- a/tests/DAVACL/PrincipalBackend/MongoTest.php
+++ b/tests/DAVACL/PrincipalBackend/MongoTest.php
@@ -563,4 +563,54 @@ class MongoTest extends \PHPUnit\Framework\TestCase {
 
         $this->assertNull($backend->getAuthTenantByTeamCalendarEmail('notanemail'));
     }
+
+    function testProvisionUserCreatesUserAndReturnsTenant() {
+        $backend = new Mongo(self::$esndb, self::$tenant);
+        $email = 'provisioned@example.com';
+
+        $tenant = $backend->provisionUser($email);
+
+        $this->assertNotNull($tenant);
+        $this->assertEquals(self::DOMAIN_ID, (string) $tenant->domainId);
+        $this->assertEquals(\ESN\Utils\TenantType::User, $tenant->tenantType);
+
+        $created = self::$esndb->users->findOne([ 'accounts.emails' => $email ]);
+        $this->assertNotNull($created);
+        $this->assertEquals($email, $created['email']);
+        $this->assertEquals(self::DOMAIN_ID, (string) $created['domains'][0]['domain_id']);
+        $this->assertEquals('email', $created['accounts'][0]['type']);
+        $this->assertEquals((string) $created['_id'], (string) $tenant->userId);
+
+        // The freshly provisioned user is now resolvable like any other user.
+        $resolved = $backend->getAuthTenantByEmail($email);
+        $this->assertNotNull($resolved);
+        $this->assertEquals((string) $created['_id'], (string) $resolved->userId);
+
+        self::$esndb->users->deleteOne([ '_id' => $created['_id'] ]);
+    }
+
+    function testProvisionUserLowercasesEmail() {
+        $backend = new Mongo(self::$esndb, self::$tenant);
+
+        $tenant = $backend->provisionUser('MixedCase@Example.com');
+
+        $this->assertNotNull($tenant);
+        $created = self::$esndb->users->findOne([ 'accounts.emails' => 'mixedcase@example.com' ]);
+        $this->assertNotNull($created);
+
+        self::$esndb->users->deleteOne([ '_id' => $created['_id'] ]);
+    }
+
+    function testProvisionUserReturnsNullWhenDomainMissing() {
+        $backend = new Mongo(self::$esndb, self::$tenant);
+
+        $this->assertNull($backend->provisionUser('someone@unknown-domain.test'));
+        $this->assertNull(self::$esndb->users->findOne([ 'accounts.emails' => 'someone@unknown-domain.test' ]));
+    }
+
+    function testProvisionUserReturnsNullWhenEmailIsNotValid() {
+        $backend = new Mongo(self::$esndb, self::$tenant);
+
+        $this->assertNull($backend->provisionUser('notanemail'));
+    }
 }

--- a/tests/DAVACL/PrincipalBackend/MongoTest.php
+++ b/tests/DAVACL/PrincipalBackend/MongoTest.php
@@ -568,7 +568,7 @@ class MongoTest extends \PHPUnit\Framework\TestCase {
         $backend = new Mongo(self::$esndb, self::$tenant);
         $email = 'provisioned@example.com';
 
-        $tenant = $backend->provisionUser($email);
+        $tenant = $backend->provisionUser($email, 'Jane', 'Provisioned');
 
         $this->assertNotNull($tenant);
         $this->assertEquals(self::DOMAIN_ID, (string) $tenant->domainId);
@@ -580,6 +580,9 @@ class MongoTest extends \PHPUnit\Framework\TestCase {
         $this->assertEquals(self::DOMAIN_ID, (string) $created['domains'][0]['domain_id']);
         $this->assertEquals('email', $created['accounts'][0]['type']);
         $this->assertEquals((string) $created['_id'], (string) $tenant->userId);
+        // firstname/lastname are stored as provided (backed by the LDAP entry).
+        $this->assertEquals('Jane', $created['firstname']);
+        $this->assertEquals('Provisioned', $created['lastname']);
 
         // The freshly provisioned user is now resolvable like any other user.
         $resolved = $backend->getAuthTenantByEmail($email);


### PR DESCRIPTION
Closes #425

## Problem

Today, when a user authenticates successfully (LDAP or admin impersonation) but has no entry in the `users` collection yet, Sabre returns a `401 NotAuthenticated` ("User not found"). This is a problem upon migrations, where legitimate users may not have been provisioned yet.

## Change

Auto-provision the user on the fly instead of returning a `401`:

- **`PrincipalBackend\Mongo::provisionUser()`** — creates a `users` document for the given email. The document follows the format used by [twake-calendar-side-service `MongoDBOpenPaaSUserDAO`](https://github.com/linagora/twake-calendar-side-service/blob/main/storage-mongodb/src/main/java/com/linagora/calendar/storage/mongodb/MongoDBOpenPaaSUserDAO.java) (`firstname`, `lastname`, `firstnames`, `password`, `email`, `domains[].domain_id`, `accounts[].{type,emails}`) so both services share the same data model. Concurrent inserts are handled by re-reading the tenant.
- **`Auth\Backend\Esn`** — after a successful LDAP bind or admin impersonation, if the user is not found it is auto-provisioned rather than rejected. Wired for both the LDAP and impersonation code paths (as requested in the issue).
- **`PrivatePrincipalBackend`** — delegates the new method.

## Gating

New behaviour is gated by the `AUTO_PROVISION` env var, **defaulting to `true`**. Set `AUTO_PROVISION=false` to keep the legacy `401` behaviour. Documented in `doc/CONFIGURE.md`.

The domain part of the user email must match an existing domain, otherwise the user cannot be attached to a tenant and the legacy `401` is returned (no orphan users).

## Tests

- `MongoTest`: `provisionUser` creates the user + resolves it, lowercases the email, returns `null` when the domain is missing or the email is invalid.
- `EsnTest`: end-to-end auto-provisioning on the LDAP path and the impersonation path, `AUTO_PROVISION=false` still returns `401`, and provisioning is skipped when the domain is missing.

> [!NOTE]
> The PHP test suite runs inside Docker (`./run_test.sh`); it could not be executed automatically in this environment, so the added tests have not been run here.

---
*Generated automatically*
