### PR TITLE
ISSUE-441 Grant resource administrators write access to the resource calendar

### DIFF
--- a/lib/DAVACL/PrincipalBackend/Mongo.php
+++ b/lib/DAVACL/PrincipalBackend/Mongo.php
@@ -249,6 +249,37 @@ class Mongo extends \Sabre\DAVACL\PrincipalBackend\AbstractBackend {
             $principals[] = 'principals/domains/' . (string)$domain['domain_id'];
         }
 
+        return array_merge($principals, $this->administeredResourcePrincipals($id));
+    }
+
+    /**
+     * Resource principals the given user administers.
+     *
+     * A resource administrator is a member of the resource principal, so the
+     * resource calendar's owner privileges (read/write) apply to them and they
+     * can update participation on behalf of the resource (issue #441). The
+     * `administrators.id` field may be stored either as an ObjectId or as its
+     * string representation depending on the provisioning path, so both forms
+     * are matched.
+     */
+    private function administeredResourcePrincipals(string $userId): array {
+        $adminId = [ $userId ];
+        try {
+            $adminId[] = new \MongoDB\BSON\ObjectId($userId);
+        } catch (\MongoDB\Driver\Exception\Exception $e) {
+            // Not an ObjectId-shaped id: only match the string form.
+        }
+
+        $resources = $this->db->resources->find(
+            [ 'administrators.id' => [ '$in' => $adminId ] ],
+            [ 'projection' => [ '_id' => 1 ] ]
+        );
+
+        $principals = [];
+        foreach ($resources as $resource) {
+            $principals[] = 'principals/resources/' . (string)$resource['_id'];
+        }
+
         return $principals;
     }
 

--- a/lib/DAVACL/PrincipalBackend/PrivatePrincipalBackend.php
+++ b/lib/DAVACL/PrincipalBackend/PrivatePrincipalBackend.php
@@ -116,7 +116,10 @@ class PrivatePrincipalBackend extends AbstractBackend {
         }
 
         if ($prefixPath === 'principals/domains' && $this->isUserPrincipalPath($currentPrincipal)) {
-            return $this->principalBackend->getGroupMembership($currentPrincipal);
+            return array_values(array_filter(
+                $this->principalBackend->getGroupMembership($currentPrincipal),
+                fn($principalPath) => str_starts_with($principalPath, 'principals/domains/')
+            ));
         }
         return [];
     }

--- a/tests/DAVACL/PrincipalBackend/MongoTest.php
+++ b/tests/DAVACL/PrincipalBackend/MongoTest.php
@@ -145,7 +145,10 @@ class MongoTest extends \PHPUnit\Framework\TestCase {
         self::$esndb->resources->insertOne([
             '_id' => new \MongoDB\BSON\ObjectId(self::RESOURCE_ID),
             'name' => 'resource',
-            'domain' => new \MongoDB\BSON\ObjectId(self::DOMAIN_ID)
+            'domain' => new \MongoDB\BSON\ObjectId(self::DOMAIN_ID),
+            'administrators' => [
+                [ 'objectType' => 'user', 'id' => new \MongoDB\BSON\ObjectId(self::USER_ID) ]
+            ]
         ]);
         self::$esndb->team_calendars->insertOne([
             '_id' => new \MongoDB\BSON\ObjectId(self::TEAM_CALENDAR_ID),
@@ -210,6 +213,11 @@ class MongoTest extends \PHPUnit\Framework\TestCase {
                     'uri' => 'principals/domains/' . self::DOMAIN_ID,
                     'administrators' => ['principals/users/' . self::USER_DOMAIN_ADMIN_ID],
                     'members' => self::$domainMembers
+                ],
+                [
+                    'uri' => 'principals/resources/' . self::RESOURCE_ID,
+                    'administrators' => [],
+                    'members' => []
                 ]
             ]
         ];
@@ -428,10 +436,23 @@ class MongoTest extends \PHPUnit\Framework\TestCase {
     function testGetGroupMembership() {
         $backend  = new Mongo(self::$esndb, self::$tenant);
 
+        // A user is a member of their domains and of every resource they
+        // administer, so resource calendar privileges apply to them (issue #441).
+        $expected = array(
+            'principals/domains/' . self::DOMAIN_ID,
+            'principals/resources/' . self::RESOURCE_ID
+        );
+        $this->assertEquals($expected,$backend->getGroupMembership('principals/users/' . self::USER_ID));
+    }
+
+    function testGetGroupMembershipExcludesResourcesNotAdministered() {
+        $backend  = new Mongo(self::$esndb, self::$tenant);
+
+        // USER_WITH_ACCOUNT_ID does not administer any resource.
         $expected = array(
             'principals/domains/' . self::DOMAIN_ID
         );
-        $this->assertEquals($expected,$backend->getGroupMembership('principals/users/' . self::USER_ID));
+        $this->assertEquals($expected,$backend->getGroupMembership('principals/users/' . self::USER_WITH_ACCOUNT_ID));
     }
 
     function testSetGroupMemberSetPRoject() {

--- a/tests/DAVACL/ResourceAdminAclTest.php
+++ b/tests/DAVACL/ResourceAdminAclTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace ESN\DAVACL;
+
+use Sabre\HTTP\Request;
+
+/**
+ * Issue #441: an administrator of a resource must be able to update
+ * participation on behalf of the resource by writing directly to the
+ * resource calendar (calendars/{resourceId}/{resourceId}/*.ics).
+ *
+ * The administrator link lives in the resource document (`administrators`
+ * field), not as an explicit calendar share, so being an administrator has to
+ * grant the resource owner's write privileges through group membership.
+ *
+ * @medium
+ */
+class ResourceAdminAclTest extends \PHPUnit\Framework\TestCase {
+
+    private $server;
+    private $caldavBackend;
+    private $esndb;
+    private $sabredb;
+    private $aclPlugin;
+    private $authPlugin;
+
+    private $resourceId = '68fef2e630c9f300553cf04a';
+    private $adminId = '54b64eadf6d7d8e41d263e0a';
+    private $strangerId = '54b64eadf6d7d8e41d263e0d';
+    private $domainId = '54b64eadf6d7d8e41d263e0b';
+    private $eventUid = 'issue-441-event';
+
+    function setUp(): void {
+        parent::setUp();
+
+        $mcesn = new \MongoDB\Client(ESN_MONGO_ESNURI);
+        $this->esndb = $mcesn->{ESN_MONGO_ESNDB};
+
+        $mcsabre = new \MongoDB\Client(ESN_MONGO_SABREURI);
+        $this->sabredb = $mcsabre->{ESN_MONGO_SABREDB};
+
+        $this->sabredb->drop();
+        $this->esndb->drop();
+
+        $this->esndb->domains->insertOne([
+            '_id' => new \MongoDB\BSON\ObjectId($this->domainId),
+            'name' => 'linagora.com'
+        ]);
+
+        foreach ([$this->adminId, $this->strangerId] as $userId) {
+            $this->esndb->users->insertOne([
+                '_id' => new \MongoDB\BSON\ObjectId($userId),
+                'firstname' => 'User',
+                'lastname' => $userId,
+                'accounts' => [
+                    [ 'type' => 'email', 'emails' => [ $userId . '@linagora.com' ] ]
+                ],
+                'domains' => [[ 'domain_id' => new \MongoDB\BSON\ObjectId($this->domainId) ]]
+            ]);
+        }
+
+        // The admin link is stored in the resource document, exactly like the
+        // production data model reported in issue #441 (no explicit share).
+        $this->esndb->resources->insertOne([
+            '_id' => new \MongoDB\BSON\ObjectId($this->resourceId),
+            'name' => 'Meeting Room A',
+            'type' => 'calendar',
+            'domain' => new \MongoDB\BSON\ObjectId($this->domainId),
+            'administrators' => [
+                [ 'objectType' => 'user', 'id' => new \MongoDB\BSON\ObjectId($this->adminId) ]
+            ]
+        ]);
+
+        $this->initServer();
+
+        // Resource calendar plus an event to write onto.
+        $calendarId = $this->caldavBackend->createCalendar(
+            'principals/resources/' . $this->resourceId,
+            $this->resourceId,
+            [ '{DAV:}displayname' => 'Resource Calendar' ]
+        );
+        $this->caldavBackend->createCalendarObject($calendarId, $this->eventUid . '.ics', <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:{$this->eventUid}
+DTSTART:20260725T090000Z
+DTEND:20260725T093000Z
+SUMMARY:Booking
+END:VEVENT
+END:VCALENDAR
+ICS);
+    }
+
+    function testResourceAdministratorHasWriteContentOnResourceCalendar() {
+        $privileges = $this->currentUserPrivilegesFor($this->adminId);
+
+        $this->assertContains('{DAV:}write-content', $privileges,
+            'A resource administrator must be able to write to the resource calendar');
+    }
+
+    function testNonAdministratorHasNoWriteContentOnResourceCalendar() {
+        $privileges = $this->currentUserPrivilegesFor($this->strangerId);
+
+        $this->assertNotContains('{DAV:}write-content', $privileges,
+            'A user who does not administer the resource must not get write access');
+    }
+
+    private function currentUserPrivilegesFor($userId): array {
+        $path = 'calendars/' . $this->resourceId . '/' . $this->resourceId . '/' . $this->eventUid . '.ics';
+
+        $request = new Request('PUT', '/' . $path);
+        $request->setHeader('Authorization', 'Basic ' . base64_encode('principals/users/' . $userId . ':secret'));
+        $this->server->httpRequest = $request;
+        $this->authPlugin->beforeMethod($request, $this->server->httpResponse);
+
+        return $this->aclPlugin->getCurrentUserPrivilegeSet($path);
+    }
+
+    private function initServer(): void {
+        $authTenant = new \ESN\Utils\AuthTenant($this->adminId, $this->domainId);
+        $principalBackend = new \ESN\DAVACL\PrincipalBackend\Mongo($this->esndb, $authTenant);
+        $this->caldavBackend = new \ESN\CalDAV\Backend\Mongo($this->sabredb);
+
+        $tree = [];
+        $tree[] = new \Sabre\DAV\SimpleCollection('principals', [
+            new \Sabre\CalDAV\Principal\Collection($principalBackend, 'principals/users'),
+            new \ESN\CalDAV\Principal\ResourceCollection($principalBackend, 'principals/resources'),
+            new \Sabre\CalDAV\Principal\Collection($principalBackend, 'principals/domains')
+        ]);
+        $calendarRoot = new \ESN\CalDAV\CalendarRoot($principalBackend, $this->caldavBackend, $this->esndb);
+        $calendarRoot->setAuthTenant($authTenant);
+        $tree[] = $calendarRoot;
+
+        $this->server = new \Sabre\DAV\Server($tree);
+        $this->server->httpResponse = new \Sabre\HTTP\Response();
+        $this->server->debugExceptions = true;
+
+        $this->server->addPlugin(new \ESN\CalDAV\Plugin());
+        $this->server->addPlugin(new \Sabre\DAV\Sharing\Plugin());
+        $this->server->addPlugin(new \Sabre\CalDAV\SharingPlugin());
+
+        $this->authPlugin = new \Sabre\DAV\Auth\Plugin(new ResourceAdminAuthBackendMock());
+        $this->server->addPlugin($this->authPlugin);
+
+        $this->aclPlugin = new \Sabre\DAVACL\Plugin();
+        $this->aclPlugin->principalCollectionSet = ['principals/users', 'principals/resources'];
+        $this->server->addPlugin($this->aclPlugin);
+    }
+}
+
+/**
+ * Auth backend that trusts the principal encoded in the Basic credentials so a
+ * test can act as an arbitrary user.
+ */
+class ResourceAdminAuthBackendMock implements \Sabre\DAV\Auth\Backend\BackendInterface {
+
+    function check(\Sabre\HTTP\RequestInterface $request, \Sabre\HTTP\ResponseInterface $response) {
+        $auth = new \Sabre\HTTP\Auth\Basic('SabreDAV', $request, $response);
+        $credentials = $auth->getCredentials();
+
+        if (!$credentials) {
+            return [false, 'No credentials'];
+        }
+
+        return [true, $credentials[0]];
+    }
+
+    function challenge(\Sabre\HTTP\RequestInterface $request, \Sabre\HTTP\ResponseInterface $response) {
+    }
+}


### PR DESCRIPTION
Closes #441

## Problem

An administrator of a resource cannot update participation on behalf of the resource. The frontend `PUT`s the event directly to the resource calendar:

```
PUT /dav/calendars/{resourceId}/{resourceId}/<event>.ics
```

but Sabre replies `403`:

```
Sabre\DAVACL\Exception\NeedPrivileges
User did not have the required privileges ({DAV:}write-content) ...
```

The resource calendar ACL only grants the owner privileges to the resource principal itself (`principals/resources/{resourceId}`). Being listed in the resource `administrators` field granted nothing, so an admin acting under their own user credentials had no `write-content`.

## Fix

Expose the resources a user administers as **group memberships** of that user in `ESN\DAVACL\PrincipalBackend\Mongo::getGroupMembership`. DAVACL then expands the resource calendar owner ACEs (read/write) to the administrator, exactly as it already does for domain membership — no ACL bypass, staying within the standard DAVACL model.

- `administrators.id` is matched both as an `ObjectId` and as its string form, to cover both provisioning paths.
- `PrivatePrincipalBackend::visiblePrincipalPaths` now filters `getGroupMembership` to domain principals for the `principals/domains` listing, since group membership can now also contain resource principals.

## Tests

- `tests/DAVACL/ResourceAdminAclTest.php` — end-to-end reproduction of #441: an administrator (via the resource `administrators` field, **no** explicit calendar share) gets `{DAV:}write-content` on the resource calendar, while an unrelated user does not.
- `tests/DAVACL/PrincipalBackend/MongoTest.php` — `getGroupMembership` returns administered resource principals, and none for a non-administrator.

Ran the `DAVACL`, `CardDAV` and `CalDAV` suites (all green) plus `phpcs` on the changed files.

---
*Generated automatically*
