### PR TITLE
fix(caldav): allow admin delegates to write source calendars

### DIFF
--- a/lib/CalDAV/SharedCalendar.php
+++ b/lib/CalDAV/SharedCalendar.php
@@ -289,7 +289,7 @@ class SharedCalendar extends \Sabre\CalDAV\SharedCalendar {
 
     /**
      * When ORGANIZER validation is enabled (CALDAV_ORGANIZER_VALIDATION=true),
-     * delegates with read-write rights are allowed to write directly into the
+     * delegates with write-enabled rights are allowed to write directly into the
      * owner's source calendar (e.g. PUT /calendars/{owner}/{owner}/x.ics). The
      * OrganizerValidationPlugin then enforces that the ORGANIZER is either the
      * calendar owner or the authenticated user.
@@ -311,7 +311,7 @@ class SharedCalendar extends \Sabre\CalDAV\SharedCalendar {
         }
 
         foreach ($this->getInvites() as $sharee) {
-            if ((int) $sharee->access !== SPlugin::ACCESS_READWRITE || !$sharee->principal) {
+            if (!$this->isWriteEnabledAccess((int) $sharee->access) || !$sharee->principal) {
                 continue;
             }
 
@@ -328,6 +328,10 @@ class SharedCalendar extends \Sabre\CalDAV\SharedCalendar {
         }
 
         return $acl;
+    }
+
+    private function isWriteEnabledAccess(int $access): bool {
+        return in_array($access, [SPlugin::ACCESS_READWRITE, SPlugin::ACCESS_ADMINISTRATION], true);
     }
 
 }

--- a/lib/CalDAV/SharedCalendar.php
+++ b/lib/CalDAV/SharedCalendar.php
@@ -34,7 +34,7 @@ class SharedCalendar extends \Sabre\CalDAV\SharedCalendar {
         $acl = parent::getACL();
 
         $acl = $this->appendTeamCalendarMemberReadAces($acl);
-        $acl = $this->appendOrganizerValidationDelegateAces($acl);
+        $acl = $this->appendSourceCalendarDelegateWriteAces($acl);
 
         switch ($this->getShareAccess()) {
             case SPlugin::ACCESS_ADMINISTRATION :
@@ -155,7 +155,7 @@ class SharedCalendar extends \Sabre\CalDAV\SharedCalendar {
         $childACL = parent::getChildACL();
 
         $childACL = $this->appendTeamCalendarMemberReadAces($childACL);
-        $childACL = $this->appendOrganizerValidationDelegateAces($childACL);
+        $childACL = $this->appendSourceCalendarDelegateWriteAces($childACL);
 
         if ($this->getShareAccess() == SPlugin::ACCESS_ADMINISTRATION) {
             $childACL[] = [
@@ -287,26 +287,8 @@ class SharedCalendar extends \Sabre\CalDAV\SharedCalendar {
         return $acl;
     }
 
-    /**
-     * When ORGANIZER validation is enabled (CALDAV_ORGANIZER_VALIDATION=true),
-     * delegates with write-enabled rights are allowed to write directly into the
-     * owner's source calendar (e.g. PUT /calendars/{owner}/{owner}/x.ics). The
-     * OrganizerValidationPlugin then enforces that the ORGANIZER is either the
-     * calendar owner or the authenticated user.
-     *
-     * Without the flag the strict default applies: the source calendar is only
-     * writable by its owner, and delegates must go through their own delegated
-     * calendar instance.
-     *
-     * The grant only targets the owner's source instance (ACCESS_NOTSHARED);
-     * delegated instances keep their own access level untouched.
-     */
-    private function appendOrganizerValidationDelegateAces(array $acl) {
-        if (getenv('CALDAV_ORGANIZER_VALIDATION') !== 'true') {
-            return $acl;
-        }
-
-        if ($this->getShareAccess() !== SPlugin::ACCESS_NOTSHARED) {
+    private function appendSourceCalendarDelegateWriteAces(array $acl) {
+        if (!$this->shouldAppendSourceCalendarDelegateWriteAces()) {
             return $acl;
         }
 
@@ -328,6 +310,14 @@ class SharedCalendar extends \Sabre\CalDAV\SharedCalendar {
         }
 
         return $acl;
+    }
+
+    private function shouldAppendSourceCalendarDelegateWriteAces(): bool {
+        if ($this->getShareAccess() !== SPlugin::ACCESS_NOTSHARED) {
+            return false;
+        }
+
+        return Utils::isResourceFromPrincipal($this->getOwner()) || getenv('CALDAV_ORGANIZER_VALIDATION') === 'true';
     }
 
     private function isWriteEnabledAccess(int $access): bool {

--- a/run_test.sh
+++ b/run_test.sh
@@ -73,7 +73,7 @@ cleanup() {
 trap cleanup EXIT  # finally: sera exécuté *quoi qu'il arrive*
 
 javatest() {
-    git clone -b test/enable-resource-admin-participation-test https://github.com/vttranlina/twake-calendar-integration-tests.git it-tests ||  exit 1
+    git clone https://github.com/linagora/twake-calendar-integration-tests.git it-tests ||  exit 1
     cd it-tests || exit 1
     bash pre-build.sh esn_sabre_test || exit 1
     mvn clean install -Dapi.version=1.43 -Dtest=com.linagora.dav.sabrev4_7.** -Damqp.scheduling.enabled=true || exit 1

--- a/run_test.sh
+++ b/run_test.sh
@@ -73,7 +73,7 @@ cleanup() {
 trap cleanup EXIT  # finally: sera exécuté *quoi qu'il arrive*
 
 javatest() {
-    git clone https://github.com/linagora/twake-calendar-integration-tests.git it-tests ||  exit 1
+    git clone -b test/enable-resource-admin-participation-test https://github.com/vttranlina/twake-calendar-integration-tests.git it-tests ||  exit 1
     cd it-tests || exit 1
     bash pre-build.sh esn_sabre_test || exit 1
     mvn clean install -Dapi.version=1.43 -Dtest=com.linagora.dav.sabrev4_7.** -Damqp.scheduling.enabled=true || exit 1

--- a/tests/CalDAV/Schedule/ResourceAdminUpdateTest.php
+++ b/tests/CalDAV/Schedule/ResourceAdminUpdateTest.php
@@ -183,7 +183,7 @@ class ResourceAdminUpdateTest extends \PHPUnit\Framework\TestCase {
 
     function testResourceAdministratorCanWriteCanonicalResourceCalendarObjectByAcl() {
         $previous = getenv('CALDAV_ORGANIZER_VALIDATION');
-        putenv('CALDAV_ORGANIZER_VALIDATION=true');
+        putenv('CALDAV_ORGANIZER_VALIDATION=false');
 
         try {
             $eventUid = 'canonical-resource-admin-write';

--- a/tests/CalDAV/Schedule/ResourceAdminUpdateTest.php
+++ b/tests/CalDAV/Schedule/ResourceAdminUpdateTest.php
@@ -96,6 +96,7 @@ class ResourceAdminUpdateTest extends \PHPUnit\Framework\TestCase {
             [
                 new \Sabre\DAV\Xml\Element\Sharee([
                     'href' => 'mailto:' . $this->adminEmail,
+                    'principal' => 'principals/users/' . $this->adminId,
                     'access' => \Sabre\DAV\Sharing\Plugin::ACCESS_READWRITE,
                     'properties' => []
                 ])
@@ -178,6 +179,39 @@ class ResourceAdminUpdateTest extends \PHPUnit\Framework\TestCase {
         // Verify the email format
         $expectedEmail = 'mailto:' . $this->resourceId . '@linagora.com';
         $this->assertEquals($expectedEmail, $addresses[0], 'Resource email should be correctly formatted');
+    }
+
+    function testResourceAdministratorCanWriteCanonicalResourceCalendarObjectByAcl() {
+        $previous = getenv('CALDAV_ORGANIZER_VALIDATION');
+        putenv('CALDAV_ORGANIZER_VALIDATION=true');
+
+        try {
+            $eventUid = 'canonical-resource-admin-write';
+            $this->caldavBackend->createCalendarObject($this->resourceCalendar['id'], $eventUid . '.ics', <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:$eventUid
+DTSTART:20260725T090000Z
+DTEND:20260725T093000Z
+SUMMARY:Booking
+END:VEVENT
+END:VCALENDAR
+ICS);
+
+            $aclPlugin = $this->server->getPlugin('acl');
+            $this->server->getPlugin('auth')->beforeMethod($this->server->httpRequest, $this->server->httpResponse);
+            $path = 'calendars/' . $this->resourceId . '/' . $this->resourceId . '/' . $eventUid . '.ics';
+
+            $this->assertTrue(
+                $aclPlugin->checkPrivileges($path, '{DAV:}write', 0, false),
+                'Resource administrator should be able to write the canonical resource calendar object through ACL'
+            );
+        } finally {
+            $previous === false
+                ? putenv('CALDAV_ORGANIZER_VALIDATION')
+                : putenv('CALDAV_ORGANIZER_VALIDATION=' . $previous);
+        }
     }
 
     /**
@@ -289,7 +323,8 @@ ICS;
 
         $tree[] = new \Sabre\DAV\SimpleCollection('principals', [
             new \Sabre\CalDAV\Principal\Collection($principalBackend, 'principals/users'),
-            new \ESN\CalDAV\Principal\ResourceCollection($principalBackend, 'principals/resources')
+            new \ESN\CalDAV\Principal\ResourceCollection($principalBackend, 'principals/resources'),
+            new \Sabre\CalDAV\Principal\Collection($principalBackend, 'principals/domains')
         ]);
         $calendarRoot = new \ESN\CalDAV\CalendarRoot(
             $principalBackend,
@@ -319,7 +354,7 @@ ICS;
         $this->server->addPlugin($authPlugin);
 
         $aclPlugin = new \Sabre\DAVACL\Plugin();
-        $aclPlugin->principalCollectionSet = ['principals/users', 'principals/resources'];
+        $aclPlugin->principalCollectionSet = ['principals/users', 'principals/resources', 'principals/domains'];
         $this->server->addPlugin($aclPlugin);
 
         return [$caldavBackend, $authBackend];
@@ -331,6 +366,14 @@ ICS;
  */
 class TestAuthBackendMock extends \Sabre\DAV\Auth\Backend\AbstractBasic {
     protected $currentUser;
+
+    public function check(\Sabre\HTTP\RequestInterface $request, \Sabre\HTTP\ResponseInterface $response) {
+        if ($this->currentUser) {
+            return [true, $this->currentUser];
+        }
+
+        return [false, 'No current test principal configured'];
+    }
 
     public function validateUserPass($username, $password) {
         return true;

--- a/tests/CalDAV/SharedCalendarTest.php
+++ b/tests/CalDAV/SharedCalendarTest.php
@@ -167,6 +167,78 @@ class SharedCalendarTest extends \PHPUnit\Framework\TestCase {
         $this->assertContains($expectedReadAce, $sharedCalendar->getChildACL());
     }
 
+    function testResourceSourceChildACLAllowsWriteEnabledDelegates() {
+        $previous = getenv('CALDAV_ORGANIZER_VALIDATION');
+        putenv('CALDAV_ORGANIZER_VALIDATION=true');
+
+        try {
+            foreach ([\Sabre\DAV\Sharing\Plugin::ACCESS_READWRITE, \ESN\DAV\Sharing\Plugin::ACCESS_ADMINISTRATION] as $access) {
+                $props = [
+                    'id'           => $access,
+                    'principaluri' => 'principals/resources/64b64eadf6d7d8e41d263e0f',
+                ];
+                $backend = new SimpleBackendMock([$props], [], []);
+                $backend->updateInvites($access, [
+                    new \Sabre\DAV\Xml\Element\Sharee([
+                        'href'      => 'mailto:admin@example.org',
+                        'principal' => 'principals/users/admin',
+                        'access'    => $access,
+                    ]),
+                ]);
+
+                $sharedCalendar = new SharedCalendar(new \Sabre\CalDAV\SharedCalendar($backend, $props));
+
+                $this->assertContains(
+                    [
+                        'privilege' => '{DAV:}write',
+                        'principal' => 'principals/users/admin',
+                        'protected' => true,
+                    ],
+                    $sharedCalendar->getChildACL()
+                );
+            }
+        } finally {
+            $previous === false
+                ? putenv('CALDAV_ORGANIZER_VALIDATION')
+                : putenv('CALDAV_ORGANIZER_VALIDATION=' . $previous);
+        }
+    }
+
+    function testResourceSourceChildACLRejectsReadOnlyDelegates() {
+        $previous = getenv('CALDAV_ORGANIZER_VALIDATION');
+        putenv('CALDAV_ORGANIZER_VALIDATION=true');
+
+        try {
+            $props = [
+                'id'           => 1,
+                'principaluri' => 'principals/resources/64b64eadf6d7d8e41d263e0f',
+            ];
+            $backend = new SimpleBackendMock([$props], [], []);
+            $backend->updateInvites(1, [
+                new \Sabre\DAV\Xml\Element\Sharee([
+                    'href'      => 'mailto:reader@example.org',
+                    'principal' => 'principals/users/reader',
+                    'access'    => \Sabre\DAV\Sharing\Plugin::ACCESS_READ,
+                ]),
+            ]);
+
+            $sharedCalendar = new SharedCalendar(new \Sabre\CalDAV\SharedCalendar($backend, $props));
+
+            $this->assertNotContains(
+                [
+                    'privilege' => '{DAV:}write',
+                    'principal' => 'principals/users/reader',
+                    'protected' => true,
+                ],
+                $sharedCalendar->getChildACL()
+            );
+        } finally {
+            $previous === false
+                ? putenv('CALDAV_ORGANIZER_VALIDATION')
+                : putenv('CALDAV_ORGANIZER_VALIDATION=' . $previous);
+        }
+    }
+
 
     function testGetChildACLAdministrationShareAccess() {
         $props = [

--- a/tests/CalDAV/SharedCalendarTest.php
+++ b/tests/CalDAV/SharedCalendarTest.php
@@ -168,10 +168,7 @@ class SharedCalendarTest extends \PHPUnit\Framework\TestCase {
     }
 
     function testResourceSourceChildACLAllowsWriteEnabledDelegates() {
-        $previous = getenv('CALDAV_ORGANIZER_VALIDATION');
-        putenv('CALDAV_ORGANIZER_VALIDATION=true');
-
-        try {
+        $this->withOrganizerValidation('false', function () {
             foreach ([\Sabre\DAV\Sharing\Plugin::ACCESS_READWRITE, \ESN\DAV\Sharing\Plugin::ACCESS_ADMINISTRATION] as $access) {
                 $props = [
                     'id'           => $access,
@@ -197,28 +194,48 @@ class SharedCalendarTest extends \PHPUnit\Framework\TestCase {
                     $sharedCalendar->getChildACL()
                 );
             }
-        } finally {
-            $previous === false
-                ? putenv('CALDAV_ORGANIZER_VALIDATION')
-                : putenv('CALDAV_ORGANIZER_VALIDATION=' . $previous);
-        }
+        });
     }
 
     function testResourceSourceChildACLRejectsReadOnlyDelegates() {
-        $previous = getenv('CALDAV_ORGANIZER_VALIDATION');
-        putenv('CALDAV_ORGANIZER_VALIDATION=true');
+        $props = [
+            'id'           => 1,
+            'principaluri' => 'principals/resources/64b64eadf6d7d8e41d263e0f',
+        ];
+        $backend = new SimpleBackendMock([$props], [], []);
+        $backend->updateInvites(1, [
+            new \Sabre\DAV\Xml\Element\Sharee([
+                'href'      => 'mailto:reader@example.org',
+                'principal' => 'principals/users/reader',
+                'access'    => \Sabre\DAV\Sharing\Plugin::ACCESS_READ,
+            ]),
+        ]);
 
-        try {
+        $sharedCalendar = new SharedCalendar(new \Sabre\CalDAV\SharedCalendar($backend, $props));
+
+        $this->assertNotContains(
+            [
+                'privilege' => '{DAV:}write',
+                'principal' => 'principals/users/reader',
+                'protected' => true,
+            ],
+            $sharedCalendar->getChildACL()
+        );
+    }
+
+
+    function testUserSourceChildACLRejectsWriteEnabledDelegatesWhenOrganizerValidationDisabled() {
+        $this->withOrganizerValidation('false', function () {
             $props = [
                 'id'           => 1,
-                'principaluri' => 'principals/resources/64b64eadf6d7d8e41d263e0f',
+                'principaluri' => 'principals/users/64b64eadf6d7d8e41d263e0f',
             ];
             $backend = new SimpleBackendMock([$props], [], []);
             $backend->updateInvites(1, [
                 new \Sabre\DAV\Xml\Element\Sharee([
-                    'href'      => 'mailto:reader@example.org',
-                    'principal' => 'principals/users/reader',
-                    'access'    => \Sabre\DAV\Sharing\Plugin::ACCESS_READ,
+                    'href'      => 'mailto:admin@example.org',
+                    'principal' => 'principals/users/admin',
+                    'access'    => \Sabre\DAV\Sharing\Plugin::ACCESS_READWRITE,
                 ]),
             ]);
 
@@ -227,11 +244,48 @@ class SharedCalendarTest extends \PHPUnit\Framework\TestCase {
             $this->assertNotContains(
                 [
                     'privilege' => '{DAV:}write',
-                    'principal' => 'principals/users/reader',
+                    'principal' => 'principals/users/admin',
                     'protected' => true,
                 ],
                 $sharedCalendar->getChildACL()
             );
+        });
+    }
+
+    function testUserSourceChildACLAllowsWriteEnabledDelegatesWhenOrganizerValidationEnabled() {
+        $this->withOrganizerValidation('true', function () {
+            $props = [
+                'id'           => 1,
+                'principaluri' => 'principals/users/64b64eadf6d7d8e41d263e0f',
+            ];
+            $backend = new SimpleBackendMock([$props], [], []);
+            $backend->updateInvites(1, [
+                new \Sabre\DAV\Xml\Element\Sharee([
+                    'href'      => 'mailto:admin@example.org',
+                    'principal' => 'principals/users/admin',
+                    'access'    => \Sabre\DAV\Sharing\Plugin::ACCESS_READWRITE,
+                ]),
+            ]);
+
+            $sharedCalendar = new SharedCalendar(new \Sabre\CalDAV\SharedCalendar($backend, $props));
+
+            $this->assertContains(
+                [
+                    'privilege' => '{DAV:}write',
+                    'principal' => 'principals/users/admin',
+                    'protected' => true,
+                ],
+                $sharedCalendar->getChildACL()
+            );
+        });
+    }
+
+    private function withOrganizerValidation(string $value, callable $callback) {
+        $previous = getenv('CALDAV_ORGANIZER_VALIDATION');
+        putenv('CALDAV_ORGANIZER_VALIDATION=' . $value);
+
+        try {
+            $callback();
         } finally {
             $previous === false
                 ? putenv('CALDAV_ORGANIZER_VALIDATION')


### PR DESCRIPTION
resolve https://github.com/linagora/esn-sabre/issues/441

The 403 happens on the canonical resource calendar URL because the source calendar child ACL only considered `ACCESS_READWRITE` delegates writable