### PR TITLE
fix(security): remove legacy JSON query endpoint

### DIFF
--- a/lib/JSON/CalDAV/CalendarObjectHandler.php
+++ b/lib/JSON/CalDAV/CalendarObjectHandler.php
@@ -26,50 +26,6 @@ class CalendarObjectHandler {
         $this->currentUser = $currentUser;
     }
 
-    public function queryCalendarObjects($nodePath, $node, $jsonData) {
-        if (!isset($jsonData) || !isset($jsonData->scope) ||
-            !isset($jsonData->scope->calendars)) {
-            return [400, null];
-        }
-
-        $calendars = $jsonData->scope->calendars;
-        $baseUri = $this->server->getBaseUri();
-        $baseUriLen = strlen($baseUri);
-        $items = [];
-        $calendarHandler = new CalendarHandler($this->server, $this->currentUser);
-
-        foreach ($calendars as $calendarPath) {
-            if (substr($calendarPath, 0, $baseUriLen) == $baseUri) {
-                $calendarPath = substr($calendarPath, $baseUriLen);
-            }
-
-            if (substr($calendarPath, -5) == '.json') {
-                $calendarPath = substr($calendarPath, 0, -5);
-            }
-
-            $node = $this->server->tree->getNodeForPath($calendarPath);
-
-            if ($node instanceof \Sabre\CalDAV\ICalendarObjectContainer) {
-                $calendar = $calendarHandler->calendarToJson($calendarPath, $node);
-                list(, $calendarObjects) = $this->getCalendarObjects($calendarPath, $node, $jsonData);
-                $calendar['_embedded'] = [
-                    'dav:item' => $calendarObjects['_embedded']['dav:item']
-                ];
-                $items[] = $calendar;
-            }
-        }
-
-        $requestPath = $this->server->getBaseUri() . $nodePath . '.json';
-        $result = [
-            '_links' => [
-              'self' => [ 'href' => $requestPath ]
-            ],
-            '_embedded' => [ 'dav:calendar' => $items ]
-        ];
-
-        return [200, $result];
-    }
-
     public function getCalendarObjectByUID($nodePath, $node, $jsonData) {
         if (!isset($jsonData->uid)) {
             return [400, null];

--- a/lib/JSON/Plugin.php
+++ b/lib/JSON/Plugin.php
@@ -327,12 +327,6 @@ class Plugin extends \Sabre\CalDAV\Plugin {
         $code = null;
         $body = null;
 
-        if ($path == 'query') {
-            $jsonData = json_decode($request->getBodyAsString());
-            list($code, $body) = $this->getCalendarObjectHandler()->queryCalendarObjects($path, null, $jsonData);
-            return $this->send($code, $body);
-        }
-
         $node = $this->server->tree->getNodeForPath($path);
 
         // Only handle calendar nodes, let other plugins handle other nodes (like addressbooks)

--- a/tests/JSON/PluginTest.php
+++ b/tests/JSON/PluginTest.php
@@ -570,7 +570,7 @@ END:VCALENDAR
         $this->assertEquals($response->status, 404);
     }
 
-    function testMultiQuery() {
+    function testMultiQueryEndpointIsNotAvailable() {
         $request = \Sabre\HTTP\Sapi::createFromServerArray(array(
             'REQUEST_METHOD'    => 'POST',
             'HTTP_CONTENT_TYPE' => 'application/json',
@@ -580,61 +580,7 @@ END:VCALENDAR
 
         $request->setBody(json_encode($this->timeRangeData));
         $response = $this->request($request);
-        $this->assertEquals($response->status, 200);
-        $jsonResponse = json_decode($response->getBodyAsString());
-
-        $this->assertEquals('/query.json', $jsonResponse->_links->self->href);
-        $calendars = $jsonResponse->_embedded->{'dav:calendar'};
-        $this->assertCount(1, $calendars);
-
-        $this->assertEquals($calendars[0]->{'_links'}->self->href, '/calendars/54b64eadf6d7d8e41d263e0f/calendar1.json');
-        $this->assertEquals($calendars[0]->{'dav:name'}, 'Calendar');
-        $this->assertEquals($calendars[0]->{'caldav:description'}, 'description');
-        $this->assertEquals($calendars[0]->{'calendarserver:ctag'}, 'http://sabre.io/ns/sync/4');
-        $this->assertEquals($calendars[0]->{'apple:color'}, '#0190FFFF');
-        $this->assertEquals($calendars[0]->{'apple:order'}, '2');
-
-        $items = $calendars[0]->_embedded->{'dav:item'};
-        $this->assertCount(1, $items);
-    }
-
-    function testMultiQueryMissingScope() {
-        $request = \Sabre\HTTP\Sapi::createFromServerArray(array(
-            'REQUEST_METHOD'    => 'POST',
-            'HTTP_CONTENT_TYPE' => 'application/json',
-            'HTTP_ACCEPT'       => 'application/json',
-            'REQUEST_URI'       => '/query.json',
-        ));
-
-        $data = $this->timeRangeData;
-        unset($data['scope']['calendars']);
-
-        $request->setBody(json_encode($data));
-        $response = $this->request($request);
-        $this->assertEquals($response->status, 400);
-    }
-
-    function testMultiQueryWithJsonSuffix() {
-        $request = \Sabre\HTTP\Sapi::createFromServerArray(array(
-            'REQUEST_METHOD'    => 'POST',
-            'HTTP_CONTENT_TYPE' => 'application/json',
-            'HTTP_ACCEPT'       => 'application/json',
-            'REQUEST_URI'       => '/query.json',
-        ));
-
-        $data = $this->timeRangeData;
-        $data['scope']['calendars'][0] .= '.json';
-
-        $request->setBody(json_encode($data));
-        $response = $this->request($request);
-        $this->assertEquals($response->status, 200);
-        $jsonResponse = json_decode($response->getBodyAsString());
-
-        $calendars = $jsonResponse->_embedded->{'dav:calendar'};
-        $this->assertCount(1, $calendars);
-
-        $items = $calendars[0]->_embedded->{'dav:item'};
-        $this->assertCount(1, $items);
+        $this->assertEquals($response->status, 404);
     }
 
     private function checkCalendars($calendars) {


### PR DESCRIPTION
Remove the JSON `/query.json` multi-query endpoint handling from the JSON plugin.

## Why
Because the endpoint is unused by the current product flow, non-standard, and security-sensitive, removing it is safer than keeping and maintaining an additional access-control path.

- The current Twake Calendar frontend does not use this endpoint
- The side-service does not use this endpoint
- This endpoint appears to be legacy OpenPaaS JSON API surface. (maybe)
- This is non-standard (RFC) endpoint.
- Keeping it exposed increases ACL risk: it accepts caller-provided calendar paths in `scope.calendars`, which can bypass the usual path-based CalDAV REPORT handling if ACL checks are incomplete.
Detail:  https://github.com/linagora/twake-calendar-integration-tests/pull/317