### PR TITLE
ISSUE-445 fix(security): anonymize private events in JSON allEvents endpoint

### DIFF
--- a/lib/JSON/Plugin.php
+++ b/lib/JSON/Plugin.php
@@ -406,7 +406,7 @@ class Plugin extends \Sabre\CalDAV\Plugin {
             foreach ($children as $child) {
                 $items[] = [
                     '_links' => [ 'self' => [ 'href' => '/' . $path . '/' . $child->getName() ] ],
-                    'data' => $child->get()
+                    'data' => $this->sanitizePrivateEvents($child->get(), $node)
                 ];
             }
 
@@ -424,6 +424,31 @@ class Plugin extends \Sabre\CalDAV\Plugin {
 
         $withRights = $this->getBooleanParameter($queryParams, 'withRights');
         return $this->getCalendarHandler()->getCalendarInformation($path, $node, $withRights);
+    }
+
+    private function sanitizePrivateEvents($calendarData, $calendarNode) {
+        if (is_resource($calendarData)) {
+            $calendarData = stream_get_contents($calendarData);
+        }
+
+        try {
+            $vCalendar = VObject\Reader::read($calendarData);
+        } catch (\Exception $e) {
+            return $calendarData;
+        }
+
+        if (!isset($vCalendar->VEVENT)) {
+            $vCalendar->destroy();
+            return $calendarData;
+        }
+
+        $sanitizedCalendar = Utils::hidePrivateEventInfoForUser($vCalendar, $calendarNode, $this->currentUser);
+        $result = $sanitizedCalendar->serialize();
+
+        $vCalendar->destroy();
+        $sanitizedCalendar->destroy();
+
+        return $result;
     }
 
     private function getSubscription($path, $node, $queryParams) {

--- a/tests/JSON/PluginTest.php
+++ b/tests/JSON/PluginTest.php
@@ -979,6 +979,55 @@ END:VCALENDAR
         $this->assertEquals(sizeof($jsonResponse->_embedded->{'dav:item'}), 3);
     }
 
+    function testGetAllEventsAnonymizesPrivateEventsForNonOwner() {
+        $request = \Sabre\HTTP\Sapi::createFromServerArray(array(
+            'REQUEST_METHOD'    => 'GET',
+            'HTTP_CONTENT_TYPE' => 'application/json',
+            'HTTP_ACCEPT'       => 'application/json',
+            'REQUEST_URI'       => '/calendars/54b64eadf6d7d8e41d263e0e/publicCal1.json?allEvents=true',
+        ));
+
+        $response = $this->request($request);
+        $jsonResponse = json_decode($response->getBodyAsString());
+        $this->assertEquals($response->status, 200);
+
+        $items = $jsonResponse->_embedded->{'dav:item'};
+        $this->assertCount(1, $items);
+        $this->assertStringNotContainsString('RecurringPrivate', $items[0]->data);
+
+        $vcalendar = \Sabre\VObject\Reader::read($items[0]->data);
+        $vevents = $vcalendar->select('VEVENT');
+        $this->assertCount(2, $vevents);
+        $this->assertEquals('Busy', $vevents[0]->SUMMARY->getValue());
+        $this->assertEquals('PRIVATE', $vevents[0]->CLASS->getValue());
+        $this->assertFalse(isset($vevents[0]->LOCATION));
+        $this->assertEquals('Exception', $vevents[1]->SUMMARY->getValue());
+    }
+
+    function testGetAllEventsKeepsPrivateEventDetailsForOwner() {
+        $this->authBackend->setPrincipal('principals/users/54b64eadf6d7d8e41d263e0e');
+
+        $request = \Sabre\HTTP\Sapi::createFromServerArray(array(
+            'REQUEST_METHOD'    => 'GET',
+            'HTTP_CONTENT_TYPE' => 'application/json',
+            'HTTP_ACCEPT'       => 'application/json',
+            'REQUEST_URI'       => '/calendars/54b64eadf6d7d8e41d263e0e/publicCal1.json?allEvents=true',
+        ));
+
+        $response = $this->request($request);
+        $jsonResponse = json_decode($response->getBodyAsString());
+        $this->assertEquals($response->status, 200);
+
+        $items = $jsonResponse->_embedded->{'dav:item'};
+        $this->assertCount(1, $items);
+
+        $vcalendar = \Sabre\VObject\Reader::read($items[0]->data);
+        $vevents = $vcalendar->select('VEVENT');
+        $this->assertCount(2, $vevents);
+        $this->assertEquals('RecurringPrivate', $vevents[0]->SUMMARY->getValue());
+        $this->assertEquals('Paris', $vevents[0]->LOCATION->getValue());
+    }
+
     function testCreateCalendar() {
         $request = \Sabre\HTTP\Sapi::createFromServerArray(array(
             'REQUEST_METHOD'    => 'POST',


### PR DESCRIPTION
Closes #445

## Problem

`GET /calendars/{ownerId}/{calendarId}.json?allEvents=true` returned the raw stored iCalendar data for every object in the calendar. On a publicly readable calendar, any user could read the `SUMMARY`, `LOCATION` and other sensitive fields of events marked `CLASS:PRIVATE` or `CLASS:CONFIDENTIAL`, while every other read path (JSON REPORT, expand, DAV GET/PROPFIND) already anonymizes them as `Busy`.

## Fix

In `JSON\Plugin::getCalendar()`, each object returned by the `allEvents=true` branch is now passed through `Utils::hidePrivateEventInfoForUser()` — the same helper used by all other read paths — before being serialized into the response. For non-owners, private events keep only UID, dates, recurrence info and organizer, with `SUMMARY:Busy` and `CLASS:PRIVATE`. The calendar owner still sees full details, and `Utils::isHiddenPrivateEvent()` keeps handling the team-calendar and subscription special cases.

## Tests

Two regression tests added to `tests/JSON/PluginTest.php`:
- a non-owner querying a publicly readable calendar with `allEvents=true` gets the private event anonymized (`SUMMARY:Busy`, no `LOCATION`, original summary absent from the payload), while the non-private exception occurrence stays intact;
- the calendar owner still receives the full private event details.

`tests/JSON/PluginTest.php` suite: **OK (90 tests, 392 assertions)** (run in the `esn_sabre_test` docker environment).

Note: as discussed in the issue, if this legacy parameter turns out to be unused, removing it entirely (like the multi-query endpoint in d0adf2f) remains an option — this PR closes the data leak in the meantime.

---
*Generated automatically*
