### PR TITLE
ISSUE-445-fix(json): remove unsupported allEvents calendar JSON shortcut

### DIFF
--- a/lib/JSON/Plugin.php
+++ b/lib/JSON/Plugin.php
@@ -399,29 +399,6 @@ class Plugin extends \Sabre\CalDAV\Plugin {
     }
 
     private function getCalendar($path, $node, $queryParams) {
-        if ($this->getBooleanParameter($queryParams, 'allEvents')) {
-            $children = $node->getChildren();
-            $items = [];
-
-            foreach ($children as $child) {
-                $items[] = [
-                    '_links' => [ 'self' => [ 'href' => '/' . $path . '/' . $child->getName() ] ],
-                    'data' => $child->get()
-                ];
-            }
-
-            $result = [
-                '_links' => [
-                    'self' => [ 'href' => '/' . $path . '.json' ]
-                ],
-                '_embedded'=> [
-                    'dav:item' => $items
-                ]
-            ];
-
-            return [200, $result];
-        }
-
         $withRights = $this->getBooleanParameter($queryParams, 'withRights');
         return $this->getCalendarHandler()->getCalendarInformation($path, $node, $withRights);
     }

--- a/tests/JSON/PluginTest.php
+++ b/tests/JSON/PluginTest.php
@@ -964,7 +964,7 @@ END:VCALENDAR
         $this->assertEquals($jsonResponse->{'apple:order'}, '2');
     }
 
-    function testGetAllEventsInCalendar() {
+    function testGetCalendarIgnoresUnsupportedAllEventsParameter() {
         $request = \Sabre\HTTP\Sapi::createFromServerArray(array(
             'REQUEST_METHOD'    => 'GET',
             'HTTP_CONTENT_TYPE' => 'application/json',
@@ -975,8 +975,9 @@ END:VCALENDAR
         $response = $this->request($request);
         $jsonResponse = json_decode($response->getBodyAsString());
         $this->assertEquals($response->status, 200);
-        $this->assertEquals($jsonResponse->_links->self->href, '/calendars/54b64eadf6d7d8e41d263e0f/calendar1.json');
-        $this->assertEquals(sizeof($jsonResponse->_embedded->{'dav:item'}), 3);
+        $this->assertEquals($jsonResponse->{'_links'}->self->href, '/calendars/54b64eadf6d7d8e41d263e0f/calendar1.json');
+        $this->assertObjectNotHasProperty('_embedded', $jsonResponse);
+        $this->assertEquals($jsonResponse->{'dav:name'}, 'Calendar');
     }
 
     function testCreateCalendar() {


### PR DESCRIPTION
resolve https://github.com/linagora/esn-sabre/issues/445

Remove support for the non-standard allEvents query parameter on calendar JSON GET endpoints.

The allEvents shortcut exposed calendar object payloads through `GET /calendars/{home}/{calendar}.json?allEvents=true`. Calendar event retrieval should go through the existing REPORT flows instead.

this parameter is not used in the calendar-frontend or side-service projects, so the proposal is to remove it