### PR TITLE
Fix bug: Team Calendar - Missing X-OPENPAAS-TEAM-CALENDAR-ID after MOVE an event from Personal to a Team Calendar

### DIFF
--- a/esn.php
+++ b/esn.php
@@ -262,6 +262,7 @@ if (!empty($config['amqp']['host'])) {
     $subscriptionRealTimePlugin = new ESN\Publisher\CardDAV\SubscriptionRealTimePlugin($AMQPPublisher, $addressbookBackend);
     $server->addPlugin($subscriptionRealTimePlugin);
 
+    $server->addPlugin(new ESN\CalDAV\TeamCalendarMetadataPlugin());
     $server->addPlugin(new ESN\CalDAV\Schedule\AMQPSchedulePlugin($AMQPPublisher, $principalBackend));
 }
 

--- a/lib/CalDAV/OrganizerValidationPlugin.php
+++ b/lib/CalDAV/OrganizerValidationPlugin.php
@@ -4,12 +4,15 @@ namespace ESN\CalDAV;
 
 use ESN\DAV\Sharing\Plugin as SharingPlugin;
 use ESN\Utils\Utils;
+use Sabre\CalDAV\ICalendarObject;
+use Sabre\CalDAV\Schedule\ISchedulingObject;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Server;
 use Sabre\DAV\ServerPlugin;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
 use Sabre\VObject\Component\VCalendar;
+use Sabre\VObject\Reader;
 
 class OrganizerValidationPlugin extends ServerPlugin {
 
@@ -18,6 +21,7 @@ class OrganizerValidationPlugin extends ServerPlugin {
     function initialize(Server $server) {
         $this->server = $server;
         $server->on('calendarObjectChange', [$this, 'calendarObjectChange'], Plugin::PRIORITY_BEFORE_SCHEDULING - 10);
+        $server->on('beforeMove', [$this, 'beforeMove'], 45);
     }
 
     function getPluginName() {
@@ -40,23 +44,46 @@ class OrganizerValidationPlugin extends ServerPlugin {
             return;
         }
 
-        $vevents = $vCal->select('VEVENT');
-        if (empty($vevents)) {
-            return;
-        }
-
-        $organizerUri = $this->extractOrganizerUri($vevents);
-        if ($organizerUri === null) {
-            return;
-        }
-
         // An attendee's copy of an invitation keeps the inviter as ORGANIZER, so
         // updates (e.g. PARTSTAT changes) are allowed as long as the ORGANIZER is
         // unchanged from the stored object: a foreign organizer can only be there
         // because scheduling delivered it or a previously validated PUT wrote it.
-        if (!$isNew && !$this->isTeamCalendarPath($calendarPath) && $organizerUri === $this->getExistingOrganizerUri($request->getPath())) {
+        $existingOrganizerUri = !$isNew && !$this->isTeamCalendarPath($calendarPath)
+            ? $this->getExistingOrganizerUri($request->getPath())
+            : null;
+        $this->validateCalendarOrganizer($vCal, $calendarPath, $existingOrganizerUri);
+    }
+
+    function beforeMove($sourcePath, $destinationPath) {
+        list($calendarPath,) = Utils::splitEventPath('/' . ltrim($destinationPath, '/'));
+        if (!$calendarPath || !$this->isTeamCalendarPath($calendarPath)) return;
+
+        try {
+            $source = $this->server->tree->getNodeForPath($sourcePath);
+        } catch (\Sabre\DAV\Exception) {
             return;
         }
+        if (!$source instanceof ICalendarObject || $source instanceof ISchedulingObject) return;
+
+        $calendarData = $source->get();
+        if (is_resource($calendarData)) $calendarData = stream_get_contents($calendarData);
+        $calendar = Reader::read($calendarData);
+        if (!$calendar instanceof VCalendar) {
+            $calendar->destroy();
+            return;
+        }
+
+        try {
+            $this->validateCalendarOrganizer($calendar, $calendarPath);
+        } finally {
+            $calendar->destroy();
+        }
+    }
+
+    private function validateCalendarOrganizer(VCalendar $calendar, $calendarPath, ?string $existingOrganizerUri = null): void {
+        $vevents = $calendar->select('VEVENT');
+        if (empty($vevents) || !($organizerUri = $this->extractOrganizerUri($vevents))) return;
+        if ($existingOrganizerUri !== null && $organizerUri === $existingOrganizerUri) return;
 
         $this->validateOrganizerAuthorized($organizerUri, $calendarPath);
     }

--- a/lib/CalDAV/Schedule/AMQPSchedulePlugin.php
+++ b/lib/CalDAV/Schedule/AMQPSchedulePlugin.php
@@ -198,10 +198,6 @@ class AMQPSchedulePlugin extends Plugin {
             $modified = true;
         }
 
-        if ($this->addTeamCalendarIdProperty($vCal, $calendarPath)) {
-            $modified = true;
-        }
-
         $isTeamCalendar = $this->isTeamCalendarPath($calendarPath);
         $actorAddresses = $this->fetchSchedulingAddresses($calendarPath, $isTeamCalendar);
         $organizerAddress = $this->extractSingleOrganizerAddress($vCal);
@@ -222,12 +218,6 @@ class AMQPSchedulePlugin extends Plugin {
 
         $this->processICalendarChange($oldObj, $vCal, $schedulingAddresses, [], $modified);
         // flushDeliveries() is called in afterCreateFile/afterWriteContent.
-    }
-
-    private function addTeamCalendarIdProperty(VCalendar $calendar, string $calendarPath): bool {
-        $calendarNode = $this->server->tree->getNodeForPath($calendarPath);
-        $owner = ($calendarNode !== null && method_exists($calendarNode, 'getOwner')) ? $calendarNode->getOwner() : null;
-        return Utils::isTeamCalendarFromPrincipal($owner) ? $this->setTeamCalendarIdProperty($calendar, basename($owner)) : false;
     }
 
     /**

--- a/lib/CalDAV/Schedule/AMQPSchedulePlugin.php
+++ b/lib/CalDAV/Schedule/AMQPSchedulePlugin.php
@@ -9,6 +9,7 @@ use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
 use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\ITip;
+use Sabre\VObject\Reader;
 
 /**
  * Async scheduling plugin — the sole scheduling plugin registered in esn.php.
@@ -33,6 +34,7 @@ class AMQPSchedulePlugin extends Plugin {
     private $pendingDeliveries = [];
     private $currentOldMessage = null;
     private $currentCalendarId = null;
+    private $localRecipientsOnly = false;
 
     public function __construct($amqpPublisher, $principalBackend = null) {
         parent::__construct($principalBackend);
@@ -45,6 +47,7 @@ class AMQPSchedulePlugin extends Plugin {
         $server->on('afterCreateFile',   [$this, 'afterWrite']);
         $server->on('afterWriteContent', [$this, 'afterWrite']);
         $server->on('afterUnbind',       [$this, 'afterUnbindFlush']);
+        $server->on('calendarObjectUpdatedByServer', [$this, 'scheduleServerUpdate']);
     }
 
     function afterWrite() {
@@ -53,6 +56,38 @@ class AMQPSchedulePlugin extends Plugin {
 
     function afterUnbindFlush() {
         $this->flushDeliveries();
+    }
+
+    function scheduleServerUpdate(string $oldCalendarData, string $newCalendarData, string $calendarPath,
+                                  array $changeProperties = [], bool $localRecipientsOnly = false) {
+        if (!$this->scheduleReply($this->server->httpRequest)) {
+            return;
+        }
+
+        $oldCalendar = CalendarObjectHelper::readCalendarObject($oldCalendarData);
+        $newCalendar = CalendarObjectHelper::readCalendarObject($newCalendarData);
+        if (!$oldCalendar || !$newCalendar) {
+            return;
+        }
+
+        $this->localRecipientsOnly = $localRecipientsOnly;
+        try {
+            // Server-originated changes are scheduled as the organizer, not the actor.
+            $organizer = $this->extractSingleOrganizerAddress($newCalendar);
+            if (!$organizer) {
+                return;
+            }
+
+            $this->currentOldMessage = $oldCalendarData;
+            $this->currentCalendarId = basename($calendarPath);
+            $modified = false;
+            $this->processICalendarChange($oldCalendar, $newCalendar, [$organizer], [], $modified, $changeProperties);
+            $this->flushDeliveries();
+        } finally {
+            $this->localRecipientsOnly = false;
+            $oldCalendar->destroy();
+            $newCalendar->destroy();
+        }
     }
 
     /**
@@ -80,6 +115,12 @@ class AMQPSchedulePlugin extends Plugin {
             // POST /itip) — use synchronous delivery.
             // EventRealTimePlugin will fire via the 'iTip' hook and publish real-time notifications.
             parent::scheduleLocalDelivery($iTipMessage);
+            return;
+        }
+
+        if ($this->localRecipientsOnly
+            && !Utils::getPrincipalByUri($iTipMessage->recipient, $this->server)) {
+            $iTipMessage->scheduleStatus = '1.0';
             return;
         }
 
@@ -209,7 +250,7 @@ class AMQPSchedulePlugin extends Plugin {
         if (!$isNew) {
             $node = $this->server->tree->getNodeForPath($request->getPath());
             $this->currentOldMessage = $node->get();
-            $oldObj = \Sabre\VObject\Reader::read($this->currentOldMessage);
+            $oldObj = Reader::read($this->currentOldMessage);
         }
 
         if ($oldObj && $this->shouldValidateAttendeeSchedulingObjectChange($request->getPath(), $isTeamCalendar)) {
@@ -286,7 +327,7 @@ class AMQPSchedulePlugin extends Plugin {
      * permission error, not found) — callers must fall back to the original ICS.
      */
     private function resolveFullCalendarForBroker(string $ics): ?string {
-        $vCal = \Sabre\VObject\Reader::read($ics);
+        $vCal = Reader::read($ics);
 
         $hasMaster = false;
         foreach ($vCal->VEVENT as $vevent) {

--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -644,8 +644,8 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
      *
      * As suggested by chibenwa in PR #142 review.
      */
-    protected function processICalendarChange($oldObject, VCalendar $newObject, array $addresses, array $ignore = [], &$modified = false) {
-        $messages = $this->createBroker()->parseEvent($newObject, $addresses, $oldObject);
+    protected function processICalendarChange($oldObject, VCalendar $newObject, array $addresses, array $ignore = [], &$modified = false, array $changeProperties = []) {
+        $messages = $this->createBroker($changeProperties)->parseEvent($newObject, $addresses, $oldObject);
 
         if ($messages) $modified = true;
 
@@ -674,7 +674,7 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
     /**
      * Builds an iTIP broker with the ESN-specific significant change properties.
      */
-    private function createBroker(): ITip\Broker {
+    private function createBroker(array $changeProperties = []): ITip\Broker {
         $broker = new ITip\Broker();
         // Add SUMMARY, LOCATION, DESCRIPTION to significant change properties
         // These are important for email notifications even though they're not in RFC5546 list
@@ -691,7 +691,8 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
         // participation status or re-sending the whole invitation.
         $broker->changeProperties = array_merge(
             $broker->changeProperties,
-            ['X-OPENPAAS-VIDEOCONFERENCE', 'X-OPENPAAS-BOOKING-LINK']
+            ['X-OPENPAAS-VIDEOCONFERENCE', 'X-OPENPAAS-BOOKING-LINK'],
+            $changeProperties
         );
 
         return $broker;

--- a/lib/CalDAV/TeamCalendarMetadataPlugin.php
+++ b/lib/CalDAV/TeamCalendarMetadataPlugin.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace ESN\CalDAV;
+
+use ESN\Utils\Utils;
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+use Sabre\VObject\Component\VCalendar;
+
+/**
+ * Maintains the server-owned Team Calendar routing metadata.
+ */
+class TeamCalendarMetadataPlugin extends ServerPlugin {
+    const PROPERTY = 'X-OPENPAAS-TEAM-CALENDAR-ID';
+
+    private $server;
+
+    function initialize(Server $server) {
+        $this->server = $server;
+        $server->on('calendarObjectChange', [$this, 'calendarObjectChange'], Plugin::PRIORITY_BEFORE_SCHEDULING + 10);
+    }
+
+    function getPluginName() { return 'caldav-team-calendar-metadata'; }
+
+    function calendarObjectChange(RequestInterface $_request, ResponseInterface $_response, VCalendar $calendar,
+        $calendarPath, &$modified, $_isNew) {
+        $modified = $this->normalize($calendar, $calendarPath) || $modified;
+    }
+
+    /** Normalizes metadata from the destination owner, never from client ICS. */
+    function normalize(VCalendar $calendar, string $calendarPath): bool {
+        $teamCalendarId = $this->teamCalendarId($calendarPath);
+        if (!$teamCalendarId) return false;
+        $modified = false;
+        foreach ($calendar->select('VEVENT') as $event) {
+            if (isset($event->{self::PROPERTY}) && $event->{self::PROPERTY}->getValue() === $teamCalendarId) {
+                continue;
+            }
+            unset($event->{self::PROPERTY});
+            $event->add(self::PROPERTY, $teamCalendarId);
+            $modified = true;
+        }
+        return $modified;
+    }
+
+    private function teamCalendarId(string $calendarPath): ?string {
+        $calendarNode = $this->server->tree->getNodeForPath($calendarPath);
+        $owner = ($calendarNode !== null && method_exists($calendarNode, 'getOwner')) ? $calendarNode->getOwner() : null;
+        return Utils::isTeamCalendarFromPrincipal($owner) ? basename($owner) : null;
+    }
+}

--- a/lib/CalDAV/TeamCalendarMetadataPlugin.php
+++ b/lib/CalDAV/TeamCalendarMetadataPlugin.php
@@ -3,11 +3,15 @@
 namespace ESN\CalDAV;
 
 use ESN\Utils\Utils;
+use Sabre\CalDAV\ICalendarObject;
+use Sabre\CalDAV\Schedule\ISchedulingObject;
+use Sabre\DAV\Exception;
 use Sabre\DAV\Server;
 use Sabre\DAV\ServerPlugin;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
 use Sabre\VObject\Component\VCalendar;
+use Sabre\VObject\Reader;
 
 /**
  * Maintains the server-owned Team Calendar routing metadata.
@@ -15,11 +19,13 @@ use Sabre\VObject\Component\VCalendar;
 class TeamCalendarMetadataPlugin extends ServerPlugin {
     const PROPERTY = 'X-OPENPAAS-TEAM-CALENDAR-ID';
 
-    private $server;
+    private $server, $movedObjectOldMessages = [];
 
     function initialize(Server $server) {
         $this->server = $server;
         $server->on('calendarObjectChange', [$this, 'calendarObjectChange'], Plugin::PRIORITY_BEFORE_SCHEDULING + 10);
+        $server->on('beforeMove', [$this, 'beforeMove'], 55);
+        $server->on('afterMove', [$this, 'afterMove'], 50);
     }
 
     function getPluginName() { return 'caldav-team-calendar-metadata'; }
@@ -45,9 +51,87 @@ class TeamCalendarMetadataPlugin extends ServerPlugin {
         return $modified;
     }
 
+    function beforeMove($sourcePath, $destinationPath) {
+        list($destinationCalendarPath,) = Utils::splitEventPath('/' . ltrim($destinationPath, '/'));
+        if (!$destinationCalendarPath || !$this->teamCalendarId($destinationCalendarPath)
+            || !($source = $this->calendarObjectAt($sourcePath))) {
+            return;
+        }
+
+        list($sourceCalendarPath,) = Utils::splitEventPath('/' . ltrim($sourcePath, '/'));
+        $sourceTeamCalendarId = $sourceCalendarPath ? $this->teamCalendarId($sourceCalendarPath) : null;
+        $this->movedObjectOldMessages[$destinationPath] = [
+            'calendarData' => $this->trustedSourceData($this->calendarData($source), $sourceTeamCalendarId),
+            'teamCalendarId' => $sourceTeamCalendarId,
+        ];
+    }
+
+    function afterMove($_sourcePath, $destinationPath) {
+        $source = $this->movedObjectOldMessages[$destinationPath] ?? null;
+        unset($this->movedObjectOldMessages[$destinationPath]);
+        list($calendarPath,) = Utils::splitEventPath('/' . ltrim($destinationPath, '/'));
+        $normalized = $calendarPath ? $this->normalizeMovedObject($destinationPath, $calendarPath) : null;
+        if ($source === null || $normalized === null) return;
+
+        list($calendarData, $modified) = $normalized;
+        if (!$modified && $source['teamCalendarId'] === $this->teamCalendarId($calendarPath)) return;
+
+        $this->server->emit('calendarObjectUpdatedByServer',
+            [$source['calendarData'], $calendarData, $calendarPath, [self::PROPERTY], true]);
+    }
+
+    private function normalizeMovedObject(string $destinationPath, string $calendarPath): ?array {
+        if (!($object = $this->calendarObjectAt($destinationPath))) return null;
+        $calendarData = $this->calendarData($object);
+        $calendar = Reader::read($calendarData);
+        if (!$calendar instanceof VCalendar) {
+            $calendar->destroy();
+            return null;
+        }
+        try {
+            $modified = $this->normalize($calendar, $calendarPath);
+            if ($modified) {
+                $calendarData = $calendar->serialize();
+                $object->put($calendarData);
+            }
+            return [$calendarData, $modified];
+        } finally {
+            $calendar->destroy();
+        }
+    }
+
+    private function trustedSourceData(string $calendarData, ?string $sourceTeamCalendarId): string {
+        if ($sourceTeamCalendarId !== null) return $calendarData;
+
+        $calendar = Reader::read($calendarData);
+        if (!$calendar instanceof VCalendar) {
+            $calendar->destroy();
+            return $calendarData;
+        }
+        try {
+            foreach ($calendar->select('VEVENT') as $event) unset($event->{self::PROPERTY});
+            return $calendar->serialize();
+        } finally {
+            $calendar->destroy();
+        }
+    }
+
     private function teamCalendarId(string $calendarPath): ?string {
         $calendarNode = $this->server->tree->getNodeForPath($calendarPath);
         $owner = ($calendarNode !== null && method_exists($calendarNode, 'getOwner')) ? $calendarNode->getOwner() : null;
         return Utils::isTeamCalendarFromPrincipal($owner) ? basename($owner) : null;
+    }
+
+    private function calendarObjectAt(string $path): ?ICalendarObject {
+        try {
+            $object = $this->server->tree->getNodeForPath($path);
+        } catch (Exception) {
+            return null;
+        }
+        return $object instanceof ICalendarObject && !$object instanceof ISchedulingObject ? $object : null;
+    }
+
+    private function calendarData(ICalendarObject $object): string {
+        return is_resource($data = $object->get()) ? (string) stream_get_contents($data) : (string) $data;
     }
 }

--- a/tests/CalDAV/OrganizerValidationPluginTest.php
+++ b/tests/CalDAV/OrganizerValidationPluginTest.php
@@ -18,6 +18,7 @@ class OrganizerValidationPluginTest extends \PHPUnit\Framework\TestCase {
     private $caldavBackend;
     private $authBackend;
     private $teamCalendarId;
+    private $user2CalendarId;
 
     const USER1_ID = '54b64eadf6d7d8e41d263e0f';
     const USER1_EMAIL = 'alice@example.org';
@@ -63,7 +64,7 @@ class OrganizerValidationPluginTest extends \PHPUnit\Framework\TestCase {
             'uri' => 'cal1',
             '{DAV:}displayname' => 'User 1 Calendar',
         ]);
-        $this->caldavBackend->createCalendar(self::USER2_PRINCIPAL, 'cal2', [
+        $this->user2CalendarId = $this->caldavBackend->createCalendar(self::USER2_PRINCIPAL, 'cal2', [
             'principaluri' => self::USER2_PRINCIPAL,
             'uri' => 'cal2',
             '{DAV:}displayname' => 'User 2 Calendar',
@@ -253,6 +254,30 @@ class OrganizerValidationPluginTest extends \PHPUnit\Framework\TestCase {
         $this->emitCalendarObjectChange($this->teamCalendarPath(), $ics);
     }
 
+    function testMoveToTeamCalendarAcceptsWriteEnabledMemberAsOrganizer() {
+        $this->shareTeamCalendarWith(self::USER2_EMAIL, self::USER2_PRINCIPAL, \Sabre\DAV\Sharing\Plugin::ACCESS_READWRITE);
+        $this->authBackend->setPrincipal(self::USER2_PRINCIPAL);
+        $sourcePath = $this->createUser2Event('move-valid', 'ORGANIZER:mailto:' . self::USER2_EMAIL);
+
+        $this->server->emit('beforeMove', [$sourcePath, $this->teamCalendarPath() . '/event.ics']);
+
+        $this->assertTrue($this->server->tree->nodeExists($sourcePath));
+    }
+
+    function testMoveToTeamCalendarRejectsUnauthorizedOrganizerBeforeSourceDeletion() {
+        $this->shareTeamCalendarWith(self::USER2_EMAIL, self::USER2_PRINCIPAL, \Sabre\DAV\Sharing\Plugin::ACCESS_READWRITE);
+        $this->authBackend->setPrincipal(self::USER2_PRINCIPAL);
+        $sourcePath = $this->createUser2Event('move-invalid', 'ORGANIZER:mailto:attacker@evil.com');
+
+        try {
+            $this->server->emit('beforeMove', [$sourcePath, $this->teamCalendarPath() . '/event.ics']);
+            $this->fail('MOVE should reject an organizer that is not a write-enabled team calendar member.');
+        } catch (\Sabre\DAV\Exception\Forbidden) {
+            $this->assertTrue($this->server->tree->nodeExists($sourcePath));
+            $this->assertFalse($this->server->tree->nodeExists($this->teamCalendarPath() . '/event.ics'));
+        }
+    }
+
     private function shareTeamCalendarWith(string $email, string $principal, int $access): void {
         $this->caldavBackend->updateInvites($this->teamCalendarId, [
             new \Sabre\DAV\Xml\Element\Sharee([
@@ -266,6 +291,11 @@ class OrganizerValidationPluginTest extends \PHPUnit\Framework\TestCase {
 
     private function teamCalendarPath(): string {
         return 'calendars/' . self::TEAM_CALENDAR_ID . '/' . self::TEAM_CALENDAR_ID;
+    }
+
+    private function createUser2Event(string $uid, string $organizer): string {
+        $this->caldavBackend->createCalendarObject($this->user2CalendarId, 'event.ics', $this->makeIcs($uid, $organizer));
+        return 'calendars/' . self::USER2_ID . '/cal2/event.ics';
     }
 
     private function makeRecurringIcs(string $uid, string $masterOrganizer, string $overrideOrganizer): string {

--- a/tests/CalDAV/TeamCalendarMetadataPluginTest.php
+++ b/tests/CalDAV/TeamCalendarMetadataPluginTest.php
@@ -4,6 +4,7 @@ namespace ESN\CalDAV;
 
 use Sabre\DAV\Server;
 use Sabre\DAV\SimpleCollection;
+use Sabre\DAV\SimpleFile;
 use Sabre\HTTP\Request;
 use Sabre\HTTP\Response;
 use Sabre\VObject\Reader;
@@ -59,16 +60,90 @@ class TeamCalendarMetadataPluginTest extends \PHPUnit\Framework\TestCase {
         $this->assertSame('team-calendar-id', $calendar->VEVENT->{TeamCalendarMetadataPlugin::PROPERTY}->getValue());
     }
 
+    function testMoveShouldNormalizeDestinationBeforeLaterAfterMoveListeners() {
+        list($server, $destinationCalendar) = $this->newServer('principals/team-calendars/team-calendar-id');
+        $event = new TeamCalendarMetadataEventTestDouble('event.ics', $this->event('forged-id'));
+        $destinationCalendar->addChild($event);
+        $observedMarker = null;
+
+        $server->on('afterMove', function () use (&$observedMarker, $event) {
+            $calendar = Reader::read($event->get());
+            $observedMarker = $calendar->VEVENT->{TeamCalendarMetadataPlugin::PROPERTY}->getValue();
+        });
+        $server->emit('afterMove', ['calendars/personal-home/personal/event.ics', 'calendars/team-home/team-calendar/event.ics']);
+
+        $this->assertSame(1, $event->putCount);
+        $this->assertSame('team-calendar-id', $observedMarker);
+    }
+
+    function testMoveShouldEmitCalendarObjectUpdatedByServer() {
+        list($server, $destinationCalendar, $sourceCalendar) = $this->newServer('principals/team-calendars/team-calendar-id');
+        $sourceCalendar->addChild(new TeamCalendarMetadataEventTestDouble('event.ics', $this->event()));
+        $destinationCalendar->addChild(new TeamCalendarMetadataEventTestDouble('event.ics', $this->event()));
+        $change = null;
+
+        $server->on('calendarObjectUpdatedByServer', function ($oldData, $newData, $calendarPath, $changeProperties, $localRecipientsOnly) use (&$change) {
+            $change = [$oldData, $newData, $calendarPath, $changeProperties, $localRecipientsOnly];
+        });
+
+        $sourcePath = 'calendars/personal-home/personal/event.ics';
+        $destinationPath = 'calendars/team-home/team-calendar/event.ics';
+        $server->emit('beforeMove', [$sourcePath, $destinationPath]);
+        $server->emit('afterMove', [$sourcePath, $destinationPath]);
+
+        $this->assertNotNull($change);
+        $this->assertFalse(isset(Reader::read($change[0])->VEVENT->{TeamCalendarMetadataPlugin::PROPERTY}));
+        $this->assertSame('team-calendar-id', Reader::read($change[1])->VEVENT->{TeamCalendarMetadataPlugin::PROPERTY}->getValue());
+        $this->assertSame('calendars/team-home/team-calendar', $change[2]);
+        $this->assertSame([TeamCalendarMetadataPlugin::PROPERTY], $change[3]);
+        $this->assertTrue($change[4]);
+    }
+
+    function testMoveShouldNotTrustMatchingMarkerFromPersonalCalendar() {
+        list($server, $destinationCalendar, $sourceCalendar) = $this->newServer('principals/team-calendars/team-calendar-id');
+        $sourceCalendar->addChild(new TeamCalendarMetadataEventTestDouble('event.ics', $this->event('team-calendar-id')));
+        $destinationEvent = new TeamCalendarMetadataEventTestDouble('event.ics', $this->event('team-calendar-id'));
+        $destinationCalendar->addChild($destinationEvent);
+        $change = null;
+        $server->on('calendarObjectUpdatedByServer', function ($oldData, $newData) use (&$change) {
+            $change = [$oldData, $newData];
+        });
+
+        $sourcePath = 'calendars/personal-home/personal/event.ics';
+        $destinationPath = 'calendars/team-home/team-calendar/event.ics';
+        $server->emit('beforeMove', [$sourcePath, $destinationPath]);
+        $server->emit('afterMove', [$sourcePath, $destinationPath]);
+
+        $this->assertNotNull($change);
+        $this->assertFalse(isset(Reader::read($change[0])->VEVENT->{TeamCalendarMetadataPlugin::PROPERTY}));
+        $this->assertSame('team-calendar-id', Reader::read($change[1])->VEVENT->{TeamCalendarMetadataPlugin::PROPERTY}->getValue());
+        $this->assertSame(0, $destinationEvent->putCount);
+    }
+
+    function testMoveShouldLeaveNonTeamDestinationUntouched() {
+        list($server, $destinationCalendar) = $this->newServer('principals/users/alice');
+        $event = new TeamCalendarMetadataEventTestDouble('event.ics', $this->event('forged-id'));
+        $destinationCalendar->addChild($event);
+
+        $server->emit('afterMove', ['calendars/personal-home/personal/event.ics', 'calendars/team-home/team-calendar/event.ics']);
+
+        $this->assertSame(0, $event->putCount);
+        $calendar = Reader::read($event->get());
+        $this->assertSame('forged-id', $calendar->VEVENT->{TeamCalendarMetadataPlugin::PROPERTY}->getValue());
+    }
+
     private function newServer(string $owner): array {
         $calendar = new TeamCalendarMetadataCalendarTestDouble('team-calendar', $owner);
+        $personalCalendar = new SimpleCollection('personal');
         $server = new Server([
             new SimpleCollection('calendars', [
                 new SimpleCollection('team-home', [$calendar]),
+                new SimpleCollection('personal-home', [$personalCalendar]),
             ]),
         ]);
         $server->addPlugin(new TeamCalendarMetadataPlugin());
 
-        return [$server, $calendar];
+        return [$server, $calendar, $personalCalendar];
     }
 
     private function emitPut(Server $server, $calendar, array $headers = [], string $query = ''): bool {
@@ -104,5 +179,20 @@ class TeamCalendarMetadataCalendarTestDouble extends SimpleCollection {
 
     function getOwner() {
         return $this->owner;
+    }
+}
+
+class TeamCalendarMetadataEventTestDouble extends SimpleFile implements \Sabre\CalDAV\ICalendarObject {
+    public $putCount = 0;
+
+    function put($data) {
+        if (is_resource($data)) {
+            $data = stream_get_contents($data);
+        }
+
+        $this->contents = $data;
+        $this->putCount++;
+
+        return $this->getETag();
     }
 }

--- a/tests/CalDAV/TeamCalendarMetadataPluginTest.php
+++ b/tests/CalDAV/TeamCalendarMetadataPluginTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace ESN\CalDAV;
+
+use Sabre\DAV\Server;
+use Sabre\DAV\SimpleCollection;
+use Sabre\HTTP\Request;
+use Sabre\HTTP\Response;
+use Sabre\VObject\Reader;
+
+class TeamCalendarMetadataPluginTest extends \PHPUnit\Framework\TestCase {
+    function testShouldReplaceClientSuppliedMarkerWithDestinationTeamCalendarId() {
+        list($server,) = $this->newServer('principals/team-calendars/team-calendar-id');
+        $calendar = Reader::read($this->event('forged-id'));
+
+        $modified = $this->emitPut($server, $calendar);
+
+        $this->assertTrue($modified);
+        $this->assertSame('team-calendar-id', $calendar->VEVENT->{TeamCalendarMetadataPlugin::PROPERTY}->getValue());
+    }
+
+    function testShouldAddMissingMarkerToEveryVevent() {
+        list($server,) = $this->newServer('principals/team-calendars/team-calendar-id');
+        $calendar = Reader::read($this->event());
+
+        $modified = $this->emitPut($server, $calendar);
+
+        $this->assertTrue($modified);
+        $this->assertSame('team-calendar-id', $calendar->VEVENT->{TeamCalendarMetadataPlugin::PROPERTY}->getValue());
+    }
+
+    function testShouldLeavePersonalCalendarEventUntouched() {
+        list($server,) = $this->newServer('principals/users/alice');
+        $calendar = Reader::read($this->event());
+
+        $modified = $this->emitPut($server, $calendar);
+
+        $this->assertFalse($modified);
+        $this->assertFalse(isset($calendar->VEVENT->{TeamCalendarMetadataPlugin::PROPERTY}));
+    }
+
+    function testShouldNormalizeWhenScheduleReplyIsDisabled() {
+        list($server,) = $this->newServer('principals/team-calendars/team-calendar-id');
+        $calendar = Reader::read($this->event('forged-id'));
+
+        $modified = $this->emitPut($server, $calendar, ['Schedule-Reply' => 'F']);
+
+        $this->assertTrue($modified);
+        $this->assertSame('team-calendar-id', $calendar->VEVENT->{TeamCalendarMetadataPlugin::PROPERTY}->getValue());
+    }
+
+    function testShouldNormalizeImportedEvent() {
+        list($server,) = $this->newServer('principals/team-calendars/team-calendar-id');
+        $calendar = Reader::read($this->event());
+
+        $modified = $this->emitPut($server, $calendar, [], '?import');
+
+        $this->assertTrue($modified);
+        $this->assertSame('team-calendar-id', $calendar->VEVENT->{TeamCalendarMetadataPlugin::PROPERTY}->getValue());
+    }
+
+    private function newServer(string $owner): array {
+        $calendar = new TeamCalendarMetadataCalendarTestDouble('team-calendar', $owner);
+        $server = new Server([
+            new SimpleCollection('calendars', [
+                new SimpleCollection('team-home', [$calendar]),
+            ]),
+        ]);
+        $server->addPlugin(new TeamCalendarMetadataPlugin());
+
+        return [$server, $calendar];
+    }
+
+    private function emitPut(Server $server, $calendar, array $headers = [], string $query = ''): bool {
+        $modified = false;
+        $server->emit('calendarObjectChange', [
+            new Request('PUT', '/calendars/team-home/team-calendar/event.ics' . $query, $headers),
+            new Response(),
+            $calendar,
+            'calendars/team-home/team-calendar',
+            &$modified,
+            true,
+        ]);
+
+        return $modified;
+    }
+
+    private function event(?string $teamCalendarId = null): string {
+        $marker = $teamCalendarId ? 'X-OPENPAAS-TEAM-CALENDAR-ID:' . $teamCalendarId . "\r\n" : '';
+
+        return "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:event\r\nDTSTART:20260101T090000Z\r\n"
+            . $marker
+            . "END:VEVENT\r\nEND:VCALENDAR\r\n";
+    }
+}
+
+class TeamCalendarMetadataCalendarTestDouble extends SimpleCollection {
+    private $owner;
+
+    function __construct(string $name, string $owner) {
+        parent::__construct($name);
+        $this->owner = $owner;
+    }
+
+    function getOwner() {
+        return $this->owner;
+    }
+}


### PR DESCRIPTION
resolve https://github.com/linagora/esn-sabre/issues/457

## Problem

For regular calendar writes, Team Calendar business logic runs through `calendarObjectChange` before the object is stored:

```text
Sabre parses the calendar object
  ↓
Basic RFC validation
  ↓
calendarObjectChange
  ↓
Organizer validation / trusted metadata decoration / scheduling
  ↓
Save
```

However, Sabre handles `MOVE` and `COPY` through its transfer lifecycle instead:

```text
beforeMove / beforeCopy
  ↓
Sabre copies or moves the calendar object directly
  ↓
afterMove / afterCopy
  ↓
bind / unbind callbacks
```

This bypasses `calendarObjectChange`.

As a result, when an event is moved from a personal calendar into a Team Calendar:

```text
Bob personal event
  ↓ MOVE
Team Calendar event without X-OPENPAAS-TEAM-CALENDAR-ID
  ↓
Attendee updates PARTSTAT
  ↓
iTIP REPLY cannot reliably resolve and update the Team Calendar organizer event
```


## What this PR does

This PR provides a focused fix for `MOVE` into a Team Calendar:

```text
beforeMove
  ↓
Validate that the organizer is a write-enabled Team Calendar member
  ↓
Capture trusted source state
  ↓
Sabre moves the object
  ↓
afterMove
  ↓
Normalize X-OPENPAAS-TEAM-CALENDAR-ID from the destination Team Calendar
  ↓
Schedule a local metadata update to internal attendee copies
```

## Longer-term direction

`MOVE` and `COPY` bypassing the normal calendar object lifecycle is a broader maintainability issue. The long-term solution should provide a shared write pipeline for all object-changing operations:

```text
calendarObjectPrepare
  ├─ parse
  └─ normalize / repair
  ↓
calendarObjectValidate
  ├─ structural validation
  └─ business / authorization validation
  ↓
calendarObjectDecorate
  └─ trusted server enrichment
  ↓
calendarObjectProcessChange
  └─ scheduling and side effects
  ↓
Save
```

That larger refactor is tracked
Until then, this PR is a targeted and lower-risk fix for the Team Calendar `MOVE` path

Ref: https://github.com/linagora/esn-sabre/issues/450