### PR TITLE
[ENHANCEMENT] Systematize the use of config.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### New Features
 
  - ISSUE-437 Expose video conference links through the standard RFC 7986 `CONFERENCE` property — events carrying `X-OPENPAAS-VIDEOCONFERENCE` are decorated upon `PUT` (and upon iTIP delivery) so that external clients (Apple Calendar, iOS, Outlook, ...) display a join button. `X-OPENPAAS-VIDEOCONFERENCE` is kept for Twake clients, and is conversely derived from the `CONFERENCE` property of events created by external clients (#437)
+ - Every runtime setting can now be configured from `config.json` instead of the process environment. The `environment` section of `config.json` takes precedence, the process environment is still honoured as a fallback, and the built-in default applies last, so existing deployments keep working untouched. `scripts/generate_config.sh` materializes the whole section, `config.json.default` lists every key with its default value, and [doc/CONFIGURE.md](doc/CONFIGURE.md) documents all of them.
  - ISSUE-425 Auto-provision users upon a DAV request — when an LDAP or impersonated user authenticates successfully but has no entry in the `users` collection yet, the entry is created on the fly (following the twake-calendar-side-service document format) instead of returning a `401`. Gated by the `AUTO_PROVISION` env var (default `true`). Needed upon migrations (#425)
 
 ### Bug Fixes

--- a/config.json.default
+++ b/config.json.default
@@ -37,5 +37,30 @@
   "esn": {
     "apiRoot": "http://esn_host:8080",
     "calendarRoot": "http://esn_host:8080/calendar/api"
+  },
+  "environment": {
+    "SABRE_ENV": "production",
+
+    "LDAP_SERVER": "",
+    "LDAP_BASE": "",
+    "LDAP_FILTER": "",
+    "LDAP_ADMIN_DN": "",
+    "LDAP_ADMIN_PASSWORD": "",
+    "LDAP_USERNAME_MODE": "",
+
+    "SABRE_ADMIN_LOGIN": "",
+    "SABRE_ADMIN_PASSWORD": "",
+    "SABRE_IMPERSONATION_ENABLED": false,
+    "AUTO_PROVISION": true,
+    "PRINCIPAL_PRIVACY": true,
+
+    "CALDAV_BINARY_ATTACHMENT_MODE": "filter",
+    "CALDAV_ORGANIZER_VALIDATION": false,
+    "SABRE_ENFORCE_RFC_6638": true,
+    "SABRE_EMAIL_VALARM_RECIPIENT_SCHEDULING": true,
+    "TW_CAL_REPLY_PROPAGATION_THRESHOLD": 200,
+
+    "SHOULD_CREATE_INDEX": true,
+    "LOG_TRACE": false
   }
 }

--- a/doc/CONFIGURE.md
+++ b/doc/CONFIGURE.md
@@ -1,38 +1,105 @@
-## ENV variables
+## Configuration sources
 
-The Docker image relies on ENV variables to generate its configuration through [this script](../scripts/generate_config.sh).
+Every setting below can be provided either in `config.json` or as an ENV variable. They are
+resolved in this order:
 
-The following ENV variables needs to be set:
+1. the `environment` section of `config.json`
+2. the process environment
+3. the built-in default documented in the tables below
 
- - SABRE_MONGO_HOST
- - SABRE_MONGO_PORT
- - SABRE_MONGO_DBNAME
- - ESN_MONGO_HOST
- - ESN_MONGO_PORT
- - ESN_MONGO_DBNAME
- - MONGO_TIMEOUT
- - ESN_HOST
- - ESN_PORT
- - AMQP_HOST
- - AMQP_PORT
- - AMQP_LOGIN
- - AMQP_PASSWORD
- - SABRE_ENV
+Blank values (`""` or `null`) in `config.json` count as *not set* and fall through to the
+environment, so an empty entry never shadows an exported variable. A setting can therefore not
+be forced to the empty string — that matches the historical behaviour, where an unset variable
+and an empty one were equivalent.
 
- Additionally LDAP setup is done solely by ENV variables:
+In the Docker image, [`scripts/generate_config.sh`](../scripts/generate_config.sh) writes
+`config.json` from the variables exported to the container, `environment` section included, so
+exporting an ENV variable and setting the matching `config.json` key are equivalent.
+[`config.json.default`](../config.json.default) lists every key with its default value.
 
- - LDAP_ADMIN_DN
- - LDAP_ADMIN_PASSWORD
- - LDAP_BASE
- - LDAP_BASE_WITH_MAIL
- - LDAP_SERVER
- - LDAP_USERNAME_MODE
- - LDAP_FILTER (optional)
+Booleans accept `true` / `1` / `yes` / `on` and `false` / `0` / `no` / `off`, in any case, as a
+JSON string (`"true"`) or as a JSON native (`true`). Unset, empty and unparseable values all
+fall back to the default, so a flag that defaults to enabled can only be turned off by an
+explicit false-ish value.
 
-Credentials for impersonation are also set by ENV variables:
+## Infrastructure variables
 
- - SABRE_ADMIN_LOGIN
- - SABRE_ADMIN_PASSWORD
+These are read by the generation script only: they end up in the regular `config.json` sections,
+not in `environment`. Setting the target key in `config.json` directly has the same effect.
+
+| Variable | Default | Ends up in |
+|---|---|---|
+| `SABRE_MONGO_HOST` | `sabre_mongo` | `database.sabre.connectionString` |
+| `SABRE_MONGO_PORT` | `27017` | `database.sabre.connectionString` |
+| `SABRE_MONGO_DBNAME` | `sabre` | `database.sabre.connectionString` |
+| `SABRE_MONGO_URI` | unset — falls back to `host:port/dbname` | `database.sabre.connectionString` |
+| `SABRE_MONGO_USER` | unset — no credentials in the URI | `database.sabre.connectionString` |
+| `SABRE_MONGO_PASSWORD` | unset | `database.sabre.connectionString` |
+| `ESN_MONGO_HOST` | `esn_mongo` | `database.esn.connectionString` |
+| `ESN_MONGO_PORT` | `27017` | `database.esn.connectionString` |
+| `ESN_MONGO_DBNAME` | `esn` | `database.esn.connectionString` |
+| `ESN_MONGO_URI` | unset — falls back to `host:port/dbname` | `database.esn.connectionString` |
+| `ESN_MONGO_USER` | unset — no credentials in the URI | `database.esn.connectionString` |
+| `ESN_MONGO_PASSWORD` | unset | `database.esn.connectionString` |
+| `MONGO_TIMEOUT` | `10000` | `database.*.connectionOptions.connectTimeoutMS` |
+| `ESN_HOST` | `esn_host` | `esn.apiRoot`, `esn.calendarRoot` |
+| `ESN_PORT` | `8080` | `esn.apiRoot`, `esn.calendarRoot` |
+| `AMQP_HOST` | `amqp_host` | `amqp.host` |
+| `AMQP_PORT` | `5672` | `amqp.port` |
+| `AMQP_LOGIN` | `guest` | `amqp.login` |
+| `AMQP_PASSWORD` | `guest` | `amqp.password` |
+| `AMQP_VHOST` | `/` | `amqp.vhost` |
+| `AMQP_SSL_ENABLED` | `false` | `amqp.sslEnabled` |
+| `AMQP_SSL_TRUST_ALL_CERTS` | `false` | `amqp.sslTrustAllCerts` |
+
+## Runtime settings
+
+These are read by PHP on demand, through `ESN\Utils\Env`, and live in the `environment` section
+of `config.json`.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `SABRE_ENV` | `production` | `dev` adds stack traces to error responses and enables dev-only plugins |
+| `LDAP_SERVER` | unset | LDAP server URL; required for LDAP authentication |
+| `LDAP_BASE` | unset | Base DN for the user bind and the directory search |
+| `LDAP_FILTER` | unset — no extra filter | Filter ANDed into the search, e.g. `(objectClass=inetOrgPerson)` |
+| `LDAP_ADMIN_DN` | unset | Bind account used to search the directory after the user bind |
+| `LDAP_ADMIN_PASSWORD` | unset | Password of that bind account |
+| `LDAP_USERNAME_MODE` | unset — bind with the full address | Set to `username` to strip the `@domain` part before binding |
+| `SABRE_ADMIN_LOGIN` | unset — impersonation unavailable | Admin login used for impersonation |
+| `SABRE_ADMIN_PASSWORD` | unset — impersonation unavailable | Admin password used for impersonation |
+| `SABRE_IMPERSONATION_ENABLED` | `false` | Master switch for admin impersonation |
+| `AUTO_PROVISION` | `true` | Create missing users on successful authentication |
+| `PRINCIPAL_PRIVACY` | `true` | Restrict DAV principal discovery |
+| `CALDAV_BINARY_ATTACHMENT_MODE` | `filter` | Inline binary attachment policy: `allow`, `reject` or `filter` |
+| `CALDAV_ORGANIZER_VALIDATION` | `false` | Enforce `ORGANIZER` validation on calendar objects |
+| `SABRE_ENFORCE_RFC_6638` | `true` | Reject attendee updates to organizer-controlled scheduling fields |
+| `SABRE_EMAIL_VALARM_RECIPIENT_SCHEDULING` | `true` | Recipient-aware scheduling for `ACTION:EMAIL` `VALARM` components |
+| `TW_CAL_REPLY_PROPAGATION_THRESHOLD` | `200` | Attendee count above which reply propagation is skipped |
+| `SHOULD_CREATE_INDEX` | `true` | Provision MongoDB indexes on every request |
+| `LOG_TRACE` | `false` | Add exception stack traces to the logs |
+
+Both spellings are equivalent — as an ENV variable:
+
+```bash
+docker run -d -p 8001:80 \
+  -e SABRE_IMPERSONATION_ENABLED=true \
+  -e PRINCIPAL_PRIVACY=false \
+  linagora/esn-sabre
+```
+
+or in `config.json`:
+
+```json
+{
+  "environment": {
+    "SABRE_IMPERSONATION_ENABLED": true,
+    "PRINCIPAL_PRIVACY": false
+  }
+}
+```
+
+The rest of this section details the flags whose behaviour needs more than one line.
 
 Feature flag to enable or disable admin impersonation.
  - SABRE_IMPERSONATION_ENABLED
@@ -76,7 +143,7 @@ Feature flag to control how inline binary attachments (`ATTACH;ENCODING=BASE64;V
 When an attendee sends a `REPLY` such as accepting or declining an event, Sabre always updates the organizer calendar. It may also propagate that attendee `PARTSTAT` change to the other attendees. 
 If the event attendee count is greater than or equal to `TW_CAL_REPLY_PROPAGATION_THRESHOLD`, this propagation to the other attendees is skipped to avoid large fan-out work.
 
-- Default: `200`
+- Default: `200`. Unset, empty, or non-numeric values are treated as `200`.
 - Set to `0` or a negative value to disable this skip and always propagate replies.
 
 `SABRE_ENFORCE_RFC_6638` controls whether Sabre rejects attendee updates to scheduling fields that must remain organizer-controlled.
@@ -107,6 +174,15 @@ docker run -d -p 8001:80 \
   -e NGINX_RATE_BURST=30 \
   linagora/esn-sabre
 ```
+
+## Nginx basic authentication
+
+ - `NGINX_AUTH_BASIC` — unset by default, which leaves the server open. When set, its content is
+   written to `/etc/nginx/.htpasswd` and basic authentication is enabled. Commas separate the
+   entries, one `user:hashed_password` pair each.
+
+The rate-limiting and basic-authentication settings above are applied to the Nginx configuration
+by the container entrypoint, before PHP starts, so they have no `config.json` equivalent.
 
 ## create the configuration file
 

--- a/doc/storage/LDAP.md
+++ b/doc/storage/LDAP.md
@@ -1,6 +1,10 @@
 # LDAP
 
-## Environment variables
+## Settings
+
+All of them are unset by default, and can be given either as ENV variables or in the
+`environment` section of `config.json` — see [CONFIGURE.md](../CONFIGURE.md) for the resolution
+order.
 
 | Variable              | Purpose |
 |-----------------------|---------|

--- a/esn.php
+++ b/esn.php
@@ -11,10 +11,15 @@ if (!$config) {
     throw new Exception("Could not load config.json from " . realpath(CONFIG_PATH) . ", Error " . json_last_error());
 }
 $dbConfig = $config['database'];
+
+// Every setting that used to be read from the process environment now goes
+// through ESN\Utils\Env: config.json first, environment second, default last.
+\ESN\Utils\Env::init(isset($config['environment']) ? $config['environment'] : null);
+
 define('SABRE_ENV_PRODUCTION', 'production');
 define('SABRE_ENV_DEV', 'dev');
 
-define('SABRE_ENV', (!empty($config['environment']) && !empty($config['environment']['SABRE_ENV'])) ? $config['environment']['SABRE_ENV'] : SABRE_ENV_PRODUCTION);
+define('SABRE_ENV', \ESN\Utils\Env::getString('SABRE_ENV', SABRE_ENV_PRODUCTION));
 
 // settings
 date_default_timezone_set('UTC');
@@ -185,14 +190,13 @@ $server->addPlugin($privateEventPlugin);
 
 // Inline binary attachment policy (ATTACH;VALUE=BINARY)
 // CALDAV_BINARY_ATTACHMENT_MODE = allow | reject | filter (default: filter)
-$binaryAttachmentMode = getenv('CALDAV_BINARY_ATTACHMENT_MODE');
 $binaryAttachmentPlugin = new ESN\CalDAV\BinaryAttachmentPlugin(
-    $binaryAttachmentMode !== false ? $binaryAttachmentMode : ESN\CalDAV\BinaryAttachmentPlugin::MODE_FILTER
+    \ESN\Utils\Env::getString('CALDAV_BINARY_ATTACHMENT_MODE', ESN\CalDAV\BinaryAttachmentPlugin::MODE_FILTER)
 );
 $server->addPlugin($binaryAttachmentPlugin);
 
-// ORGANIZER validation (opt-in via CALDAV_ORGANIZER_VALIDATION=true)
-if (getenv('CALDAV_ORGANIZER_VALIDATION') === 'true') {
+// ORGANIZER validation (opt-in via CALDAV_ORGANIZER_VALIDATION)
+if (\ESN\Utils\Env::getBoolean('CALDAV_ORGANIZER_VALIDATION', false)) {
     $server->addPlugin(new ESN\CalDAV\OrganizerValidationPlugin());
 }
 
@@ -287,16 +291,9 @@ if (SABRE_ENV === SABRE_ENV_DEV) {
 $server->exec();
 
 function principalPrivacyEnabled() {
-    $rawPrivacyEnv = getenv('PRINCIPAL_PRIVACY');
-
-    if ($rawPrivacyEnv === false || trim($rawPrivacyEnv) === '') {
-        // Missing or empty env keeps privacy enabled; only an explicit false disables it.
-        return true;
-    }
-
-    $privacyEnabled = filter_var($rawPrivacyEnv, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
-
-    return $privacyEnabled ?? true;
+    // Missing, empty or invalid setting keeps privacy enabled; only an
+    // explicit false disables it.
+    return \ESN\Utils\Env::getBoolean('PRINCIPAL_PRIVACY', true);
 }
 
 function currentPrincipalProvider(&$server) {

--- a/lib/CalDAV/Backend/Mongo.php
+++ b/lib/CalDAV/Backend/Mongo.php
@@ -369,11 +369,9 @@ class Mongo extends \Sabre\CalDAV\Backend\AbstractBackend implements
     }
 
     private function ensureIndex() {
-        // Skip index creation if disabled via environment variable
+        // Skip index creation if disabled through configuration
         // Rational: calling createIndex on every request doesn't make sense in production
-        $shouldCreateIndex = getenv('SHOULD_CREATE_INDEX');
-        $isUndefined = $shouldCreateIndex === false;
-        if ($isUndefined || $shouldCreateIndex === 'true') {
+        if (\ESN\Utils\Env::getBoolean('SHOULD_CREATE_INDEX', true)) {
             $this->calendarDAO->ensureIndexes();
             $this->calendarInstanceDAO->ensureIndexes();
             $this->calendarObjectDAO->ensureIndexes();

--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -3,6 +3,7 @@ namespace ESN\CalDAV\Schedule;
 
 use ESN\CalDAV\Schedule\Exception\ForbiddenAttendeeSchedulingObjectChange;
 use ESN\CalDAV\VObjectPropertyRegistry;
+use ESN\Utils\Env;
 use ESN\Utils\Utils;
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
@@ -401,7 +402,7 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
 
     // Email VALARM recipient scheduling
     protected function shouldEnableEmailValarmRecipientScheduling(): bool {
-        return $this->envBoolean(self::EMAIL_VALARM_RECIPIENT_SCHEDULING_ENV, true);
+        return Env::getBoolean(self::EMAIL_VALARM_RECIPIENT_SCHEDULING_ENV, true);
     }
 
     protected function ensureValarmUids(VCalendar $calendarObject): bool {
@@ -568,14 +569,7 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
     }
 
     private function shouldEnforceRfc6638(): bool {
-        return $this->envBoolean(self::ENFORCE_RFC_6638_ENV, true);
-    }
-
-    private function envBoolean(string $name, bool $default): bool {
-        $value = getenv($name);
-        return $value === false || trim($value) === ''
-            ? $default
-            : filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? $default;
+        return Env::getBoolean(self::ENFORCE_RFC_6638_ENV, true);
     }
 
     /**
@@ -721,13 +715,11 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
     }
 
     private function getReplyPropagationThreshold(): int {
-        $raw = getenv('TW_CAL_REPLY_PROPAGATION_THRESHOLD');
+        $threshold = Env::getInteger(
+            'TW_CAL_REPLY_PROPAGATION_THRESHOLD',
+            self::DEFAULT_REPLY_PROPAGATION_THRESHOLD
+        );
 
-        if ($raw === false || $raw === '') {
-            return self::DEFAULT_REPLY_PROPAGATION_THRESHOLD;
-        }
-
-        $threshold = (int)$raw;
         if ($threshold < 0) {
             return 0;
         }

--- a/lib/CalDAV/SharedCalendar.php
+++ b/lib/CalDAV/SharedCalendar.php
@@ -3,6 +3,7 @@
 namespace ESN\CalDAV;
 
 use ESN\DAV\Sharing\Plugin as SPlugin;
+use ESN\Utils\Env;
 use ESN\Utils\Utils;
 
 #[\AllowDynamicProperties]
@@ -317,7 +318,7 @@ class SharedCalendar extends \Sabre\CalDAV\SharedCalendar {
             return false;
         }
 
-        return Utils::isResourceFromPrincipal($this->getOwner()) || getenv('CALDAV_ORGANIZER_VALIDATION') === 'true';
+        return Utils::isResourceFromPrincipal($this->getOwner()) || Env::getBoolean('CALDAV_ORGANIZER_VALIDATION', false);
     }
 
     private function isWriteEnabledAccess(int $access): bool {

--- a/lib/CardDAV/Backend/Mongo.php
+++ b/lib/CardDAV/Backend/Mongo.php
@@ -1044,11 +1044,9 @@ class Mongo extends \Sabre\CardDAV\Backend\AbstractBackend implements
     }
 
     private function ensureIndex() {
-        // Skip index creation if disabled via environment variable
+        // Skip index creation if disabled through configuration
         // Rational: calling createIndex on every request doesn't make sense in production
-        $shouldCreateIndex = getenv('SHOULD_CREATE_INDEX');
-        $isUndefined = $shouldCreateIndex === false;
-        if ($isUndefined || $shouldCreateIndex === 'true') {
+        if (\ESN\Utils\Env::getBoolean('SHOULD_CREATE_INDEX', true)) {
             // create a unique compound index on 'principaluri' and 'uri' for address book collection
             $addressBookCollection = $this->db->selectCollection($this->addressBooksTableName);
             $addressBookCollection->createIndex(

--- a/lib/DAV/Auth/Backend/Esn.php
+++ b/lib/DAV/Auth/Backend/Esn.php
@@ -7,18 +7,11 @@ use Sabre\Event\EventEmitter;
 use \Firebase\JWT\JWT;
 use \Firebase\JWT\Key;
 use \ESN\Utils\AuthTenant;
+use \ESN\Utils\Env;
 use \ESN\Utils\Principal;
 use \ESN\Utils\TenantType;
 
 define('ESN_PUBLIC_KEY', __DIR__ . '/../../../../config/esn.key.pub');
-
-define('LDAP_ADMIN_DN', getenv("LDAP_ADMIN_DN"));
-define('LDAP_ADMIN_PASSWORD', getenv("LDAP_ADMIN_PASSWORD"));
-define('LDAP_BASE', getenv("LDAP_BASE"));
-define('LDAP_SERVER', getenv("LDAP_SERVER"));
-define('LDAP_FILTER', getenv("LDAP_FILTER"));
-define('SABRE_ADMIN_LOGIN', getenv("SABRE_ADMIN_LOGIN"));
-define('SABRE_ADMIN_PASSWORD', getenv("SABRE_ADMIN_PASSWORD"));
 
 #[\AllowDynamicProperties]
 class Esn implements \Sabre\DAV\Auth\Backend\BackendInterface {
@@ -155,8 +148,7 @@ class Esn implements \Sabre\DAV\Auth\Backend\BackendInterface {
                 return $this->doImpersonation($impersonationResult);
         }
 
-        $env_ldap_username_mode = getenv('LDAP_USERNAME_MODE');
-        if ($env_ldap_username_mode == 'username') {
+        if (Env::getString('LDAP_USERNAME_MODE') === 'username') {
             $user = explode('@', $user);
             $user = $user[0];
         }
@@ -168,8 +160,11 @@ class Esn implements \Sabre\DAV\Auth\Backend\BackendInterface {
     }
 
     private function authenticateLdapUser($user, $password) {
+        $ldapBase = Env::getString('LDAP_BASE');
+        $ldapFilter = Env::getString('LDAP_FILTER');
+
         # Open LDAP connection
-        $ldapCon = ldap_connect(LDAP_SERVER);
+        $ldapCon = ldap_connect(Env::getString('LDAP_SERVER'));
         if (!$ldapCon) {
             error_log('Unable to connect to LDAP server');
             throw new AuthException('Unable to connect to LDAP server');
@@ -182,7 +177,7 @@ class Esn implements \Sabre\DAV\Auth\Backend\BackendInterface {
             $safeUser = ldap_escape($user, '', 0);
 
             try {
-                $ldapBind = ldap_bind($ldapCon, "uid=$safeUser," . LDAP_BASE, $password);
+                $ldapBind = ldap_bind($ldapCon, "uid=$safeUser," . $ldapBase, $password);
             } catch (\ErrorException $e) {
                 error_log("LDAP bind user failed for $user: " . $e->getMessage());
                 throw new  AuthException("Bad credentials");
@@ -194,7 +189,7 @@ class Esn implements \Sabre\DAV\Auth\Backend\BackendInterface {
                 throw new AuthException("Bad credentials");
             }
 
-            $ldapBind2 = ldap_bind($ldapCon, LDAP_ADMIN_DN, LDAP_ADMIN_PASSWORD);
+            $ldapBind2 = ldap_bind($ldapCon, Env::getString('LDAP_ADMIN_DN'), Env::getString('LDAP_ADMIN_PASSWORD'));
             if (!$ldapBind2) {
                 $code = ldap_errno($ldapCon);
                 $msg  = ldap_error($ldapCon);
@@ -204,10 +199,10 @@ class Esn implements \Sabre\DAV\Auth\Backend\BackendInterface {
 
             # Get real mail
             $searchResult = null;
-            if (LDAP_FILTER != null) {
-                $searchResult = ldap_search($ldapCon, LDAP_BASE, "(& (uid=$safeUser) " . LDAP_FILTER . ')');
+            if ($ldapFilter !== null) {
+                $searchResult = ldap_search($ldapCon, $ldapBase, "(& (uid=$safeUser) " . $ldapFilter . ')');
             } else {
-                $searchResult = ldap_search($ldapCon, LDAP_BASE, "(uid=$safeUser)");
+                $searchResult = ldap_search($ldapCon, $ldapBase, "(uid=$safeUser)");
             }
             $entries = ldap_get_entries($ldapCon, $searchResult);
         }
@@ -286,7 +281,10 @@ class Esn implements \Sabre\DAV\Auth\Backend\BackendInterface {
      * LDAP directory and read its content (firstname, lastname).
      */
     private function findLdapEntryByEmail(string $email): ?array {
-        $ldapCon = ldap_connect(LDAP_SERVER);
+        $ldapBase = Env::getString('LDAP_BASE');
+        $ldapFilter = Env::getString('LDAP_FILTER');
+
+        $ldapCon = ldap_connect(Env::getString('LDAP_SERVER'));
         if (!$ldapCon) {
             error_log('findLdapEntryByEmail: unable to connect to LDAP server');
             return null;
@@ -295,7 +293,7 @@ class Esn implements \Sabre\DAV\Auth\Backend\BackendInterface {
             ldap_set_option($ldapCon, LDAP_OPT_PROTOCOL_VERSION, 3);
             ldap_set_option($ldapCon, LDAP_OPT_REFERRALS, 0);
 
-            $ldapBind = ldap_bind($ldapCon, LDAP_ADMIN_DN, LDAP_ADMIN_PASSWORD);
+            $ldapBind = ldap_bind($ldapCon, Env::getString('LDAP_ADMIN_DN'), Env::getString('LDAP_ADMIN_PASSWORD'));
             if (!$ldapBind) {
                 $code = ldap_errno($ldapCon);
                 $msg  = ldap_error($ldapCon);
@@ -304,10 +302,10 @@ class Esn implements \Sabre\DAV\Auth\Backend\BackendInterface {
             }
 
             $safeEmail = ldap_escape($email, '', 0);
-            if (LDAP_FILTER != null) {
-                $searchResult = ldap_search($ldapCon, LDAP_BASE, "(& (mail=$safeEmail) " . LDAP_FILTER . ')');
+            if ($ldapFilter !== null) {
+                $searchResult = ldap_search($ldapCon, $ldapBase, "(& (mail=$safeEmail) " . $ldapFilter . ')');
             } else {
-                $searchResult = ldap_search($ldapCon, LDAP_BASE, "(mail=$safeEmail)");
+                $searchResult = ldap_search($ldapCon, $ldapBase, "(mail=$safeEmail)");
             }
             $entries = ldap_get_entries($ldapCon, $searchResult);
         } finally {
@@ -321,23 +319,22 @@ class Esn implements \Sabre\DAV\Auth\Backend\BackendInterface {
     }
 
     private function autoProvisionEnabled(): bool {
-        $env = getenv('AUTO_PROVISION');
-        if ($env === false || $env === '') {
-            return true;
-        }
-        return filter_var($env, FILTER_VALIDATE_BOOLEAN);
+        return Env::getBoolean('AUTO_PROVISION', true);
     }
 
     private function impersonationEnabled(): bool {
-        return filter_var(getenv('SABRE_IMPERSONATION_ENABLED'), FILTER_VALIDATE_BOOLEAN);
+        return Env::getBoolean('SABRE_IMPERSONATION_ENABLED', false);
     }
 
     protected function getAdminCredential(): ?array {
-        if (!SABRE_ADMIN_LOGIN || !SABRE_ADMIN_PASSWORD) {
+        $adminLogin = Env::getString('SABRE_ADMIN_LOGIN');
+        $adminPassword = Env::getString('SABRE_ADMIN_PASSWORD');
+
+        if (!$adminLogin || !$adminPassword) {
             return null;
         }
 
-        return [SABRE_ADMIN_LOGIN, SABRE_ADMIN_PASSWORD];
+        return [$adminLogin, $adminPassword];
     }
 
     private function attemptAdminImpersonation(string $username, string $password): ?string {

--- a/lib/Log/EsnLoggerProcessor.php
+++ b/lib/Log/EsnLoggerProcessor.php
@@ -15,7 +15,7 @@ class EsnLoggerProcessor implements \Monolog\Processor\ProcessorInterface
         $extras = [];
 
         foreach ($fields as $key => $value) {
-            $extras[$key] = getenv($value);
+            $extras[$key] = \ESN\Utils\Env::getString($value);
         }
 
         $this->envFields = $extras;

--- a/lib/Log/ExceptionLoggerPlugin.php
+++ b/lib/Log/ExceptionLoggerPlugin.php
@@ -13,11 +13,7 @@ class ExceptionLoggerPlugin extends DAV\ServerPlugin
 
     public function __construct($logger) {
         $this->logger = $logger;
-        $env = getenv('LOG_TRACE');
-        if ($env !== false) {
-            $env = strtolower(trim($env));
-            $this->logTrace = in_array($env, ['1','true','yes','on'], true);
-        }
+        $this->logTrace = \ESN\Utils\Env::getBoolean('LOG_TRACE', false);
     }
 
     function initialize(DAV\Server $server) {

--- a/lib/Utils/Env.php
+++ b/lib/Utils/Env.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace ESN\Utils;
+
+/**
+ * Central accessor for the runtime settings that used to be read straight from
+ * the process environment.
+ *
+ * Every setting is resolved in this order:
+ *
+ *   1. the "environment" section of config.json (see Env::init)
+ *   2. the process environment, for deployments that still export the
+ *      variables without regenerating config.json
+ *   3. the default provided by the caller
+ *
+ * Null values and empty strings are treated as "not set", so a blank entry in
+ * config.json falls through to the environment instead of shadowing it. That
+ * also means a setting cannot be forced to the empty string, which matches the
+ * previous getenv() based behaviour.
+ *
+ * Values may be given either as JSON natives (true, 42) or as strings
+ * ("true", "42"), since config.json is hand editable while the environment can
+ * only ever carry strings.
+ */
+#[\AllowDynamicProperties]
+class Env {
+
+    /**
+     * The "environment" section of config.json, keyed by variable name.
+     */
+    private static $config = [];
+
+    /**
+     * Seed the resolver with the "environment" section of config.json.
+     *
+     * Safe to call with null or a partial section; anything missing falls back
+     * to the process environment and then to the caller's default.
+     */
+    static function init($environmentConfig) {
+        self::$config = is_array($environmentConfig) ? $environmentConfig : [];
+    }
+
+    /**
+     * Drop the config.json section, leaving only the process environment.
+     *
+     * Mainly useful to isolate tests from each other.
+     */
+    static function reset() {
+        self::$config = [];
+    }
+
+    /**
+     * The raw value of a setting, or null when it is set nowhere.
+     *
+     * @return mixed
+     */
+    static function get($name) {
+        if (array_key_exists($name, self::$config)) {
+            $value = self::$config[$name];
+
+            // Non scalars can only come from a malformed config.json; ignoring
+            // them falls back to the default, which is the safe value for
+            // every setting, rather than blowing up the whole server.
+            if (is_scalar($value) && $value !== '') {
+                return $value;
+            }
+        }
+
+        $value = getenv($name);
+
+        if ($value === false || trim($value) === '') {
+            return null;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return string|null the setting as a string, or $default when unset
+     */
+    static function getString($name, $default = null) {
+        $value = self::get($name);
+
+        if ($value === null) {
+            return $default;
+        }
+
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        return trim((string) $value);
+    }
+
+    /**
+     * The setting as a boolean.
+     *
+     * Accepts the usual "1/true/yes/on" and "0/false/no/off" spellings, in any
+     * case. Unset, empty and unparseable values all yield $default, so a
+     * feature flag defaulting to true can only be turned off by an explicit
+     * false-ish value.
+     *
+     * @return bool
+     */
+    static function getBoolean($name, $default) {
+        $value = self::get($name);
+
+        if ($value === null) {
+            return $default;
+        }
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        $value = trim((string) $value);
+
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? $default;
+    }
+
+    /**
+     * The setting as an integer. Unparseable values yield $default.
+     *
+     * @return int
+     */
+    static function getInteger($name, $default) {
+        $value = self::get($name);
+
+        if ($value === null) {
+            return $default;
+        }
+
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (is_float($value)) {
+            return (int) $value;
+        }
+
+        $value = trim((string) $value);
+
+        return is_numeric($value) ? (int) $value : $default;
+    }
+}

--- a/scripts/generate_config.sh
+++ b/scripts/generate_config.sh
@@ -50,6 +50,48 @@ else
   sabre_mongo_connectionstring="mongodb://${SABRE_MONGO_URI:-${sabre_mongo_host}:${sabre_mongo_port}/${sabre_mongo_dbname}}"
 fi
 
+# Escape a value so it can be embedded in a JSON string. Newlines are folded
+# into spaces: none of these settings is expected to span lines, and a raw
+# newline would make the whole config.json unparseable.
+json_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/	/\\t/g' | tr '\n\r' '  '
+}
+
+# Settings read at runtime by PHP through ESN\Utils\Env. Only the variables
+# that are actually set get written out: anything absent keeps the default
+# documented in doc/CONFIGURE.md.
+runtime_env_vars="LDAP_SERVER
+LDAP_BASE
+LDAP_FILTER
+LDAP_ADMIN_DN
+LDAP_ADMIN_PASSWORD
+LDAP_USERNAME_MODE
+SABRE_ADMIN_LOGIN
+SABRE_ADMIN_PASSWORD
+SABRE_IMPERSONATION_ENABLED
+AUTO_PROVISION
+PRINCIPAL_PRIVACY
+CALDAV_BINARY_ATTACHMENT_MODE
+CALDAV_ORGANIZER_VALIDATION
+SABRE_ENFORCE_RFC_6638
+SABRE_EMAIL_VALARM_RECIPIENT_SCHEDULING
+TW_CAL_REPLY_PROPAGATION_THRESHOLD
+SHOULD_CREATE_INDEX
+LOG_TRACE"
+
+environment_entries="    \"SABRE_ENV\": \"$(json_escape "${sabre_env}")\""
+
+for env_var in ${runtime_env_vars}
+do
+  eval "env_value=\${${env_var}}"
+
+  if [ ! -z "${env_value}" ]
+  then
+    environment_entries="${environment_entries},
+    \"${env_var}\": \"$(json_escape "${env_value}")\""
+  fi
+done
+
 config="{
   \"webserver\": {
     \"baseUri\": \"/\",
@@ -88,8 +130,10 @@ config="{
     \"calendarRoot\": \"http://${esn_host}:${esn_port}/calendar/api\"
   },
   \"environment\": {
-    \"SABRE_ENV\": \"${sabre_env}\"
+${environment_entries}
   }
 }"
 
-echo "$config"
+# printf, not echo: dash's echo expands backslash sequences and would undo the
+# JSON escaping done above.
+printf '%s\n' "$config"

--- a/tests/Utils/EnvTest.php
+++ b/tests/Utils/EnvTest.php
@@ -2,6 +2,8 @@
 
 namespace ESN\Utils;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 #[\AllowDynamicProperties]
 class EnvTest extends \PHPUnit\Framework\TestCase {
 
@@ -127,9 +129,7 @@ class EnvTest extends \PHPUnit\Framework\TestCase {
         $this->assertTrue(Env::getBoolean(self::NAME, false));
     }
 
-    /**
-     * @dataProvider truthyValuesProvider
-     */
+    #[DataProvider('truthyValuesProvider')]
     function testGetBooleanAcceptsTruthySpellings($value) {
         Env::init([self::NAME => $value]);
 
@@ -140,9 +140,7 @@ class EnvTest extends \PHPUnit\Framework\TestCase {
         return [['true'], ['TRUE'], ['True'], ['1'], ['yes'], ['on'], [' true ']];
     }
 
-    /**
-     * @dataProvider falsyValuesProvider
-     */
+    #[DataProvider('falsyValuesProvider')]
     function testGetBooleanAcceptsFalsySpellings($value) {
         Env::init([self::NAME => $value]);
 

--- a/tests/Utils/EnvTest.php
+++ b/tests/Utils/EnvTest.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace ESN\Utils;
+
+#[\AllowDynamicProperties]
+class EnvTest extends \PHPUnit\Framework\TestCase {
+
+    const NAME = 'ESN_TEST_SETTING';
+
+    protected function setUp(): void {
+        Env::reset();
+        putenv(self::NAME);
+    }
+
+    protected function tearDown(): void {
+        Env::reset();
+        putenv(self::NAME);
+    }
+
+    // Resolution order: config.json, then environment, then default
+
+    function testGetReturnsNullWhenSetNowhere() {
+        $this->assertNull(Env::get(self::NAME));
+    }
+
+    function testGetFallsBackToTheEnvironmentWhenConfigIsEmpty() {
+        putenv(self::NAME . '=from-env');
+
+        $this->assertEquals('from-env', Env::get(self::NAME));
+    }
+
+    function testConfigTakesPrecedenceOverTheEnvironment() {
+        putenv(self::NAME . '=from-env');
+        Env::init([self::NAME => 'from-config']);
+
+        $this->assertEquals('from-config', Env::get(self::NAME));
+    }
+
+    function testEmptyConfigValueFallsBackToTheEnvironment() {
+        putenv(self::NAME . '=from-env');
+        Env::init([self::NAME => '']);
+
+        $this->assertEquals('from-env', Env::get(self::NAME));
+    }
+
+    function testNullConfigValueFallsBackToTheEnvironment() {
+        putenv(self::NAME . '=from-env');
+        Env::init([self::NAME => null]);
+
+        $this->assertEquals('from-env', Env::get(self::NAME));
+    }
+
+    function testEmptyEnvironmentValueIsTreatedAsUnset() {
+        putenv(self::NAME . '=   ');
+
+        $this->assertNull(Env::get(self::NAME));
+    }
+
+    function testNonScalarConfigValueFallsBackToTheEnvironment() {
+        putenv(self::NAME . '=from-env');
+        Env::init([self::NAME => ['nested' => true]]);
+
+        $this->assertEquals('from-env', Env::get(self::NAME));
+    }
+
+    function testNonScalarConfigValueFallsBackToTheDefault() {
+        Env::init([self::NAME => ['nested' => true]]);
+
+        $this->assertTrue(Env::getBoolean(self::NAME, true));
+        $this->assertEquals('fallback', Env::getString(self::NAME, 'fallback'));
+        $this->assertEquals(200, Env::getInteger(self::NAME, 200));
+    }
+
+    function testZeroIsAValidValue() {
+        Env::init([self::NAME => 0]);
+
+        $this->assertEquals(0, Env::getInteger(self::NAME, 200));
+        $this->assertFalse(Env::getBoolean(self::NAME, true));
+    }
+
+    function testInitIgnoresANonArraySection() {
+        Env::init(null);
+
+        $this->assertNull(Env::get(self::NAME));
+    }
+
+    function testResetDropsTheConfigSection() {
+        Env::init([self::NAME => 'from-config']);
+        Env::reset();
+
+        $this->assertNull(Env::get(self::NAME));
+    }
+
+    // getString
+
+    function testGetStringReturnsTheDefaultWhenUnset() {
+        $this->assertEquals('fallback', Env::getString(self::NAME, 'fallback'));
+        $this->assertNull(Env::getString(self::NAME));
+    }
+
+    function testGetStringTrimsSurroundingWhitespace() {
+        Env::init([self::NAME => '  filter  ']);
+
+        $this->assertEquals('filter', Env::getString(self::NAME));
+    }
+
+    function testGetStringRendersJsonBooleans() {
+        Env::init([self::NAME => true]);
+        $this->assertEquals('true', Env::getString(self::NAME));
+
+        Env::init([self::NAME => false]);
+        $this->assertEquals('false', Env::getString(self::NAME));
+    }
+
+    // getBoolean
+
+    function testGetBooleanReturnsTheDefaultWhenUnset() {
+        $this->assertTrue(Env::getBoolean(self::NAME, true));
+        $this->assertFalse(Env::getBoolean(self::NAME, false));
+    }
+
+    function testGetBooleanAcceptsJsonBooleans() {
+        Env::init([self::NAME => false]);
+        $this->assertFalse(Env::getBoolean(self::NAME, true));
+
+        Env::init([self::NAME => true]);
+        $this->assertTrue(Env::getBoolean(self::NAME, false));
+    }
+
+    /**
+     * @dataProvider truthyValuesProvider
+     */
+    function testGetBooleanAcceptsTruthySpellings($value) {
+        Env::init([self::NAME => $value]);
+
+        $this->assertTrue(Env::getBoolean(self::NAME, false));
+    }
+
+    static function truthyValuesProvider() {
+        return [['true'], ['TRUE'], ['True'], ['1'], ['yes'], ['on'], [' true ']];
+    }
+
+    /**
+     * @dataProvider falsyValuesProvider
+     */
+    function testGetBooleanAcceptsFalsySpellings($value) {
+        Env::init([self::NAME => $value]);
+
+        $this->assertFalse(Env::getBoolean(self::NAME, true));
+    }
+
+    static function falsyValuesProvider() {
+        return [['false'], ['FALSE'], ['0'], ['no'], ['off'], [' false ']];
+    }
+
+    function testGetBooleanFallsBackToTheDefaultOnUnparseableValues() {
+        Env::init([self::NAME => 'maybe']);
+
+        $this->assertTrue(Env::getBoolean(self::NAME, true));
+        $this->assertFalse(Env::getBoolean(self::NAME, false));
+    }
+
+    function testGetBooleanReadsTheEnvironment() {
+        putenv(self::NAME . '=false');
+
+        $this->assertFalse(Env::getBoolean(self::NAME, true));
+    }
+
+    // getInteger
+
+    function testGetIntegerReturnsTheDefaultWhenUnset() {
+        $this->assertEquals(200, Env::getInteger(self::NAME, 200));
+    }
+
+    function testGetIntegerAcceptsStringsAndNatives() {
+        Env::init([self::NAME => '50']);
+        $this->assertEquals(50, Env::getInteger(self::NAME, 200));
+
+        Env::init([self::NAME => 50]);
+        $this->assertEquals(50, Env::getInteger(self::NAME, 200));
+
+        Env::init([self::NAME => ' -1 ']);
+        $this->assertEquals(-1, Env::getInteger(self::NAME, 200));
+    }
+
+    function testGetIntegerFallsBackToTheDefaultOnUnparseableValues() {
+        Env::init([self::NAME => '12abc']);
+
+        $this->assertEquals(200, Env::getInteger(self::NAME, 200));
+    }
+}


### PR DESCRIPTION
Every runtime setting can now be configured from `config.json` instead of the process environment.
Environment gets used as a fallback.