### PR TITLE
fix(caldav): allow team calendar members to update canonical events

### DIFF
--- a/lib/CalDAV/SharedCalendar.php
+++ b/lib/CalDAV/SharedCalendar.php
@@ -318,7 +318,7 @@ class SharedCalendar extends \Sabre\CalDAV\SharedCalendar {
             return false;
         }
 
-        return Utils::isResourceFromPrincipal($this->getOwner()) || Env::getBoolean('CALDAV_ORGANIZER_VALIDATION', false);
+        return Utils::isResourceFromPrincipal($this->getOwner()) || Utils::isTeamCalendarFromPrincipal($this->getOwner()) || Env::getBoolean('CALDAV_ORGANIZER_VALIDATION', false);
     }
 
     private function isWriteEnabledAccess(int $access): bool {


### PR DESCRIPTION
Team calendar owners should be treated as valid organizers alongside resources owned directly by principals.

