### PR TITLE
ISSUE-450 fix bug: ORGANIZER validation is bypassed by WebDAV COPY and MOVE

### DIFF
--- a/lib/CalDAV/Exception/UnauthorizedOrganizer.php
+++ b/lib/CalDAV/Exception/UnauthorizedOrganizer.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ESN\CalDAV\Exception;
+
+use Sabre\DAV\Exception\Forbidden;
+
+/**
+ * Raised when the ORGANIZER of a calendar object is not allowed to organize in the
+ * target calendar.
+ *
+ * It is deliberately distinct from the plain Forbidden raised for structurally invalid
+ * ORGANIZER properties, so that callers can react to an authorization failure without
+ * also swallowing a malformed object.
+ */
+class UnauthorizedOrganizer extends Forbidden {
+}

--- a/lib/CalDAV/OrganizerValidationPlugin.php
+++ b/lib/CalDAV/OrganizerValidationPlugin.php
@@ -2,6 +2,7 @@
 
 namespace ESN\CalDAV;
 
+use ESN\CalDAV\Exception\UnauthorizedOrganizer;
 use ESN\DAV\Sharing\Plugin as SharingPlugin;
 use ESN\Utils\Utils;
 use Sabre\CalDAV\ICalendarObject;
@@ -22,6 +23,7 @@ class OrganizerValidationPlugin extends ServerPlugin {
         $this->server = $server;
         $server->on('calendarObjectChange', [$this, 'calendarObjectChange'], Plugin::PRIORITY_BEFORE_SCHEDULING - 10);
         $server->on('beforeMove', [$this, 'beforeMove'], 45);
+        $server->on('beforeCopy', [$this, 'beforeCopy'], 45);
     }
 
     function getPluginName() {
@@ -55,8 +57,23 @@ class OrganizerValidationPlugin extends ServerPlugin {
     }
 
     function beforeMove($sourcePath, $destinationPath) {
+        $this->validateTransferredOrganizer($sourcePath, $destinationPath);
+    }
+
+    function beforeCopy($sourcePath, $destinationPath, $depth = null) {
+        $this->validateTransferredOrganizer($sourcePath, $destinationPath);
+    }
+
+    /**
+     * SabreDAV runs COPY and MOVE through Tree::copy()/Tree::move(), which never emit
+     * calendarObjectChange and therefore skip the validation a PUT goes through. Validate the
+     * transferred object against the destination calendar, so that a transfer cannot introduce
+     * an ORGANIZER that a PUT to that same calendar would have rejected.
+     */
+    private function validateTransferredOrganizer($sourcePath, $destinationPath): void {
         list($calendarPath,) = Utils::splitEventPath('/' . ltrim($destinationPath, '/'));
-        if (!$calendarPath || !$this->isTeamCalendarPath($calendarPath)) return;
+        // Not a calendar object path: collection level transfers are left to the ACL plugin.
+        if (!$calendarPath) return;
 
         try {
             $source = $this->server->tree->getNodeForPath($sourcePath);
@@ -75,9 +92,38 @@ class OrganizerValidationPlugin extends ServerPlugin {
 
         try {
             $this->validateCalendarOrganizer($calendar, $calendarPath);
+        } catch (UnauthorizedOrganizer $e) {
+            // An attendee's copy of an invitation keeps the inviter as ORGANIZER, so rearranging
+            // one within a single calendar home stays allowed: the object is already there and
+            // the transfer hands it to nobody new.
+            if (!$this->isTransferWithinSameCalendarHome($sourcePath, $calendarPath)) {
+                throw $e;
+            }
         } finally {
             $calendar->destroy();
         }
+    }
+
+    private function isTransferWithinSameCalendarHome($sourcePath, $destinationCalendarPath): bool {
+        list($sourceCalendarPath,) = Utils::splitEventPath('/' . ltrim($sourcePath, '/'));
+        if (!$sourceCalendarPath) return false;
+
+        if ($this->calendarHomeOf($sourceCalendarPath) !== $this->calendarHomeOf($destinationCalendarPath)) {
+            return false;
+        }
+        
+        return !$this->isSharedInstance($destinationCalendarPath);
+    }
+
+    private function calendarHomeOf(string $calendarPath): string {
+        // $calendarPath is 'calendars/{baseId}/{calendarUri}'.
+        return explode('/', $calendarPath)[1];
+    }
+
+    private function isSharedInstance($calendarPath): bool {
+        $calendarNode = $this->getCalendarNode($calendarPath);
+
+        return $calendarNode instanceof SharedCalendar && $calendarNode->isSharedInstance();
     }
 
     private function validateCalendarOrganizer(VCalendar $calendar, $calendarPath, ?string $existingOrganizerUri = null): void {
@@ -158,7 +204,7 @@ class OrganizerValidationPlugin extends ServerPlugin {
 
         $organizerPrincipal = $aclPlugin->getPrincipalByUri($organizerUri);
         if ($organizerPrincipal === null) {
-            throw new Forbidden('The ORGANIZER must be either the calendar owner or the authenticated user.');
+            throw new UnauthorizedOrganizer('The ORGANIZER must be either the calendar owner or the authenticated user.');
         }
 
         if ($this->isTeamCalendarPath($calendarPath)) {
@@ -166,7 +212,7 @@ class OrganizerValidationPlugin extends ServerPlugin {
                 return;
             }
 
-            throw new Forbidden('The ORGANIZER must be a write-enabled team calendar member.');
+            throw new UnauthorizedOrganizer('The ORGANIZER must be a write-enabled team calendar member.');
         }
 
         if ($organizerPrincipal === $this->getCalendarOwner($calendarPath)) {

--- a/run_test.sh
+++ b/run_test.sh
@@ -75,6 +75,7 @@ trap cleanup EXIT  # finally: sera exécuté *quoi qu'il arrive*
 javatest() {
     git clone https://github.com/linagora/twake-calendar-integration-tests.git it-tests ||  exit 1
     cd it-tests || exit 1
+    git checkout test-sabre-450 || exit 1
     bash pre-build.sh esn_sabre_test || exit 1
     mvn clean install -Dapi.version=1.43 -Dtest=com.linagora.dav.sabrev4_7.** -Damqp.scheduling.enabled=true || exit 1
 }


### PR DESCRIPTION
For simplicity, only allow COPY and MOVE with the same baseId (exclude case team calendar) 