### PR TITLE
ISSUE-409 Fix VALARM scheduling merge logic

### DIFF
--- a/doc/ALARM-SCHEDULING.md
+++ b/doc/ALARM-SCHEDULING.md
@@ -185,13 +185,13 @@ copy. A personal alarm:
 - MUST NOT propagate to the organizer or other attendees;
 - MAY target the attendee's primary address or another personal address;
 - MUST be preserved when organizer-managed alarms are updated;
-- when created by a Twake client, MUST use a UID different from every
+- when assigned by a Twake client, MUST use a UID different from every
   organizer-managed alarm on the event.
 
 Editing an organizer-managed alarm and creating a personal alarm are different
-operations. Twake clients SHOULD create a new `VALARM` with a new UID when a
-user chooses a personal reminder instead of mutating the organizer-managed
-component into a personal one.
+operations. Twake clients SHOULD create a new `VALARM` when a user chooses a
+personal reminder instead of mutating the organizer-managed component into a
+personal one. They MAY assign a UID or let esn-sabre generate it.
 
 ## UID rules
 
@@ -200,20 +200,22 @@ alarms without UID for compatibility.
 
 When `SABRE_EMAIL_VALARM_RECIPIENT_SCHEDULING` is enabled, esn-sabre MUST
 generate a UID for every `VALARM` missing one before persisting and scheduling
-the event. Generated UIDs MUST use the `alarm-{uuid}` format with a UUID v4
-value. If the client already provides a UID, esn-sabre MUST preserve it.
+the event. Generated email alarm UIDs MUST use `alarm-organizer-{uuid}` for
+organizer alarms and `alarm-personal-{uuid}` for attendee-local alarms. If the
+client already provides a UID, esn-sabre MUST preserve it. Clients MAY omit the
+UID, but SHOULD preserve the server-generated value returned by subsequent
+event reads for later full-resource writes.
 
-UID provides stable identity for matching alarm updates. It does not express
-ownership by itself:
+UID provides stable identity for matching alarm updates. For server-generated
+email alarms, its prefix also expresses ownership:
 
 - alarms projected from the organizer source are organizer-managed;
 - alarms created only in an attendee copy are personal.
 
-UID SHOULD be used to match an old organizer-managed alarm with its updated
-version. Legacy UID-less alarms MAY be compared against previous and current
-organizer projections, but identical UID-less organizer and personal alarms are
-inherently ambiguous. Clients avoid that ambiguity by assigning a new UID to
-personal alarms.
+When applying an organizer `REQUEST`, an attendee copy MUST discard old email
+alarms whose UID starts with `alarm-organizer-`, or the same UID as an incoming
+organizer alarm, before adding the latest projection. Remaining alarms are
+preserved.
 
 ## Recurring events
 

--- a/lib/CalDAV/Schedule/AMQPSchedulePlugin.php
+++ b/lib/CalDAV/Schedule/AMQPSchedulePlugin.php
@@ -240,10 +240,6 @@ class AMQPSchedulePlugin extends Plugin {
         // attendees never learnt about a booking that got turned down.
         $restrictToBooker = $this->shouldRestrictSchedulingToBooker($vCal);
 
-        if ($this->shouldEnableEmailValarmRecipientScheduling() && $this->ensureValarmUids($vCal)) {
-            $modified = true;
-        }
-
         $isTeamCalendar = $this->isTeamCalendarPath($calendarPath);
         $actorAddresses = $this->fetchSchedulingAddresses($calendarPath, $isTeamCalendar);
         $organizerAddress = $this->extractSingleOrganizerAddress($vCal);
@@ -256,6 +252,11 @@ class AMQPSchedulePlugin extends Plugin {
             $node = $this->server->tree->getNodeForPath($request->getPath());
             $this->currentOldMessage = $node->get();
             $oldObj = Reader::read($this->currentOldMessage);
+        }
+
+        $isAttendeeCalendarWrite = !$isTeamCalendar && $this->isAttendeeSchedulingObject($oldObj ?? $vCal, $actorAddresses);
+        if ($this->shouldEnableEmailValarmRecipientScheduling() && $this->ensureValarmUids($vCal, $isAttendeeCalendarWrite)) {
+            $modified = true;
         }
 
         if ($oldObj && $this->shouldValidateAttendeeSchedulingObjectChange($request->getPath(), $isTeamCalendar)) {

--- a/lib/CalDAV/Schedule/AMQPSchedulePlugin.php
+++ b/lib/CalDAV/Schedule/AMQPSchedulePlugin.php
@@ -254,10 +254,8 @@ class AMQPSchedulePlugin extends Plugin {
             $oldObj = Reader::read($this->currentOldMessage);
         }
 
-        $isAttendeeCalendarWrite = !$isTeamCalendar && $this->isAttendeeSchedulingObject($oldObj ?? $vCal, $actorAddresses);
-        if ($this->shouldEnableEmailValarmRecipientScheduling() && $this->ensureValarmUids($vCal, $isAttendeeCalendarWrite)) {
-            $modified = true;
-        }
+        $isAttendeeCalendarWrite = $this->isAttendeeCalendarWrite($oldObj ?? $vCal, $isTeamCalendar, $actorAddresses);
+        $this->ensureManagedEmailValarmUids($vCal, $isAttendeeCalendarWrite, $modified);
 
         if ($oldObj && $this->shouldValidateAttendeeSchedulingObjectChange($request->getPath(), $isTeamCalendar)) {
             $this->assertAllowedAttendeeSchedulingObjectChange($oldObj, $vCal, $actorAddresses);

--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -40,6 +40,8 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
     private const PUBLIC_AGENDA_METADATA_PROPERTIES = ['X-PUBLICLY-CREATED', 'X-PUBLICLY-CREATOR', 'X-PUBLICLY-DELETED', 'X-PUBLICLY-CANCELLED-BY', 'X-OPENPAAS-BOOKING-LINK'];
     private const ENFORCE_RFC_6638_ENV = 'SABRE_ENFORCE_RFC_6638';
     private const EMAIL_VALARM_RECIPIENT_SCHEDULING_ENV = 'SABRE_EMAIL_VALARM_RECIPIENT_SCHEDULING';
+    private const ORGANIZER_MANAGED_VALARM_UID_PREFIX = 'alarm-organizer-';
+    private const PERSONAL_MANAGED_VALARM_UID_PREFIX = 'alarm-personal-';
 
     private $logger;
     private $principalBackend;
@@ -119,6 +121,9 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
 
         if ($currentObject) {
             $this->normalizeIncomingReplyMessage($iTipMessage, $currentObject);
+        }
+        if ($iTipMessage->method === 'REQUEST' && $this->shouldEnableEmailValarmRecipientScheduling()) {
+            $this->ensureValarmUids($iTipMessage->message, false);
         }
 
         $broker = new ITip\Broker();
@@ -405,13 +410,16 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
         return Env::getBoolean(self::EMAIL_VALARM_RECIPIENT_SCHEDULING_ENV, true);
     }
 
-    protected function ensureValarmUids(VCalendar $calendarObject): bool {
+    protected function ensureValarmUids(VCalendar $calendarObject, bool $isAttendeeCalendarWrite): bool {
         $modified = false;
 
         foreach ($calendarObject->select('VEVENT') as $event) {
             foreach ($event->select('VALARM') as $alarm) {
                 if (!isset($alarm->UID) || trim($alarm->UID->getValue()) === '') {
-                    $alarm->UID = 'alarm-' . \Sabre\DAV\UUIDUtil::getUUID();
+                    $prefix = $this->isEmailAlarm($alarm)
+                        ? ($isAttendeeCalendarWrite ? self::PERSONAL_MANAGED_VALARM_UID_PREFIX : self::ORGANIZER_MANAGED_VALARM_UID_PREFIX)
+                        : 'alarm-';
+                    $alarm->UID = $prefix . \Sabre\DAV\UUIDUtil::getUUID();
                     $modified = true;
                 }
             }
@@ -429,10 +437,12 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
         }
 
         $newEmailAlarmUids = array_filter(array_map(fn ($alarm) => isset($alarm->UID) ? $alarm->UID->getValue() : null, $newEmailAlarms));
-        $eventAttendees = array_map(fn ($attendee) => strtolower($attendee->getNormalizedValue()), $newEvent->select('ATTENDEE'));
 
         foreach ($oldEvent->select('VALARM') as $oldAlarm) {
-            if ($this->isEmailAlarm($oldAlarm) && $this->isOrganizerManagedEmailAlarm($oldAlarm, $newEmailAlarmUids, $eventAttendees)) {
+            $oldAlarmUid = isset($oldAlarm->UID) ? $oldAlarm->UID->getValue() : null;
+            if ($this->isEmailAlarm($oldAlarm)
+                && (str_starts_with($oldAlarmUid ?? '', self::ORGANIZER_MANAGED_VALARM_UID_PREFIX)
+                    || in_array($oldAlarmUid, $newEmailAlarmUids, true))) {
                 continue;
             }
 
@@ -442,16 +452,6 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
 
     private function isEmailAlarm($alarm): bool {
         return isset($alarm->ACTION) && strcasecmp($alarm->ACTION->getValue(), 'EMAIL') === 0;
-    }
-
-    private function isOrganizerManagedEmailAlarm($alarm, array $newEmailAlarmUids, array $eventAttendees): bool {
-        if (isset($alarm->UID) && in_array($alarm->UID->getValue(), $newEmailAlarmUids, true)) {
-            return true;
-        }
-
-        $alarmAttendees = array_map(fn ($attendee) => strtolower($attendee->getNormalizedValue()), $alarm->select('ATTENDEE'));
-
-        return !empty($alarmAttendees) && empty(array_diff($alarmAttendees, $eventAttendees));
     }
 
     /**
@@ -511,10 +511,6 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
         // attendees never learnt about a booking that got turned down.
         $restrictToBooker = $this->shouldRestrictSchedulingToBooker($vCal);
 
-        if ($this->shouldEnableEmailValarmRecipientScheduling() && $this->ensureValarmUids($vCal)) {
-            $modified = true;
-        }
-
         $isTeamCalendar = $this->isTeamCalendarPath($calendarPath);
         $actorAddresses = $this->fetchSchedulingAddresses($calendarPath, $isTeamCalendar);
         $organizerAddress = $this->extractSingleOrganizerAddress($vCal);
@@ -525,6 +521,11 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
             $oldObj = Reader::read($node->get());
         } else {
             $oldObj = null;
+        }
+
+        $isAttendeeCalendarWrite = !$isTeamCalendar && $this->isAttendeeSchedulingObject($oldObj ?? $vCal, $actorAddresses);
+        if ($this->shouldEnableEmailValarmRecipientScheduling() && $this->ensureValarmUids($vCal, $isAttendeeCalendarWrite)) {
+            $modified = true;
         }
 
         if ($oldObj && $this->shouldValidateAttendeeSchedulingObjectChange($request->getPath(), $isTeamCalendar)) {
@@ -559,7 +560,7 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
         }
     }
 
-    private function isAttendeeSchedulingObject(VCalendar $calendarObject, array $addresses): bool {
+    protected function isAttendeeSchedulingObject(VCalendar $calendarObject, array $addresses): bool {
         $normalizedAddresses = array_map('strtolower', $addresses);
         $isAttendee = false;
         $hasOrganizer = false;

--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -122,9 +122,7 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
         if ($currentObject) {
             $this->normalizeIncomingReplyMessage($iTipMessage, $currentObject);
         }
-        if ($iTipMessage->method === 'REQUEST' && $this->shouldEnableEmailValarmRecipientScheduling()) {
-            $this->ensureValarmUids($iTipMessage->message, false);
-        }
+        $this->ensureOrganizerValarmUidsForRequest($iTipMessage);
 
         $broker = new ITip\Broker();
         $newObject = $broker->processMessage($iTipMessage, $currentObject);
@@ -410,6 +408,26 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
         return Env::getBoolean(self::EMAIL_VALARM_RECIPIENT_SCHEDULING_ENV, true);
     }
 
+    private function ensureOrganizerValarmUidsForRequest(ITip\Message $iTipMessage): void {
+        if ($iTipMessage->method !== 'REQUEST') {
+            return;
+        }
+        if (!$this->shouldEnableEmailValarmRecipientScheduling()) {
+            return;
+        }
+
+        $this->ensureValarmUids($iTipMessage->message, false);
+    }
+
+    protected function ensureManagedEmailValarmUids(VCalendar $calendarObject, bool $isAttendeeCalendarWrite, bool &$modified): void {
+        if (!$this->shouldEnableEmailValarmRecipientScheduling()) {
+            return;
+        }
+        if ($this->ensureValarmUids($calendarObject, $isAttendeeCalendarWrite)) {
+            $modified = true;
+        }
+    }
+
     protected function ensureValarmUids(VCalendar $calendarObject, bool $isAttendeeCalendarWrite): bool {
         $modified = false;
 
@@ -439,15 +457,25 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
         $newEmailAlarmUids = array_filter(array_map(fn ($alarm) => isset($alarm->UID) ? $alarm->UID->getValue() : null, $newEmailAlarms));
 
         foreach ($oldEvent->select('VALARM') as $oldAlarm) {
-            $oldAlarmUid = isset($oldAlarm->UID) ? $oldAlarm->UID->getValue() : null;
-            if ($this->isEmailAlarm($oldAlarm)
-                && (str_starts_with($oldAlarmUid ?? '', self::ORGANIZER_MANAGED_VALARM_UID_PREFIX)
-                    || in_array($oldAlarmUid, $newEmailAlarmUids, true))) {
+            if ($this->shouldRemoveOldRecipientEmailAlarm($oldAlarm, $newEmailAlarmUids)) {
                 continue;
             }
 
             $newEvent->add(clone $oldAlarm);
         }
+    }
+
+    private function shouldRemoveOldRecipientEmailAlarm($alarm, array $newEmailAlarmUids): bool {
+        if (!$this->isEmailAlarm($alarm)) {
+            return false;
+        }
+
+        $alarmUid = isset($alarm->UID) ? $alarm->UID->getValue() : null;
+        if (str_starts_with($alarmUid ?? '', self::ORGANIZER_MANAGED_VALARM_UID_PREFIX)) {
+            return true;
+        }
+
+        return in_array($alarmUid, $newEmailAlarmUids, true);
     }
 
     private function isEmailAlarm($alarm): bool {
@@ -523,10 +551,8 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
             $oldObj = null;
         }
 
-        $isAttendeeCalendarWrite = !$isTeamCalendar && $this->isAttendeeSchedulingObject($oldObj ?? $vCal, $actorAddresses);
-        if ($this->shouldEnableEmailValarmRecipientScheduling() && $this->ensureValarmUids($vCal, $isAttendeeCalendarWrite)) {
-            $modified = true;
-        }
+        $isAttendeeCalendarWrite = $this->isAttendeeCalendarWrite( $oldObj ?? $vCal, $isTeamCalendar, $actorAddresses );
+        $this->ensureManagedEmailValarmUids($vCal, $isAttendeeCalendarWrite, $modified);
 
         if ($oldObj && $this->shouldValidateAttendeeSchedulingObjectChange($request->getPath(), $isTeamCalendar)) {
             // RFC 6638 permits attendee-local updates, but not organizer-controlled event fields.
@@ -576,6 +602,16 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
         }
 
         return $hasOrganizer && $isAttendee;
+    }
+
+    protected function isAttendeeCalendarWrite(VCalendar $calendarObject, bool $isTeamCalendar, array $actorAddresses): bool
+    {
+        // Team calendar changes are organizer-managed even when the connected member is an attendee.
+        if ($isTeamCalendar) {
+            return false;
+        }
+
+        return $this->isAttendeeSchedulingObject($calendarObject, $actorAddresses);
     }
 
     private function shouldEnforceRfc6638(): bool {

--- a/run_test.sh
+++ b/run_test.sh
@@ -73,7 +73,7 @@ cleanup() {
 trap cleanup EXIT  # finally: sera exécuté *quoi qu'il arrive*
 
 javatest() {
-    git clone https://github.com/linagora/twake-calendar-integration-tests.git it-tests ||  exit 1
+    git clone -b test/same-recipient-valarm-uid-merge https://github.com/vttranlina/twake-calendar-integration-tests.git it-tests ||  exit 1
     cd it-tests || exit 1
     bash pre-build.sh esn_sabre_test || exit 1
     mvn clean install -Dapi.version=1.43 -Dtest=com.linagora.dav.sabrev4_7.** -Damqp.scheduling.enabled=true || exit 1

--- a/run_test.sh
+++ b/run_test.sh
@@ -73,7 +73,7 @@ cleanup() {
 trap cleanup EXIT  # finally: sera exécuté *quoi qu'il arrive*
 
 javatest() {
-    git clone -b test/same-recipient-valarm-uid-merge https://github.com/vttranlina/twake-calendar-integration-tests.git it-tests ||  exit 1
+    git clone https://github.com/linagora/twake-calendar-integration-tests.git it-tests ||  exit 1
     cd it-tests || exit 1
     bash pre-build.sh esn_sabre_test || exit 1
     mvn clean install -Dapi.version=1.43 -Dtest=com.linagora.dav.sabrev4_7.** -Damqp.scheduling.enabled=true || exit 1

--- a/tests/CalDAV/Schedule/SchedulePluginTest.php
+++ b/tests/CalDAV/Schedule/SchedulePluginTest.php
@@ -592,7 +592,7 @@ END:VALARM
 BEGIN:VALARM
 UID:alice-personal-reminder@example.org
 ACTION:EMAIL
-ATTENDEE:mailto:alias@example.org
+ATTENDEE:mailto:alice@example.org
 TRIGGER:-PT10M
 DESCRIPTION:Personal reminder
 SUMMARY:Personal alarm notification
@@ -636,7 +636,7 @@ ICS
             $this->assertEquals('-PT20M', $alarmsByUid['organizer-reminder@example.org']->TRIGGER->getValue());
             $this->assertEquals('mailto:alice@example.org', $alarmsByUid['organizer-reminder@example.org']->ATTENDEE->getNormalizedValue());
             $this->assertEquals('-PT10M', $alarmsByUid['alice-personal-reminder@example.org']->TRIGGER->getValue());
-            $this->assertEquals('mailto:alias@example.org', $alarmsByUid['alice-personal-reminder@example.org']->ATTENDEE->getNormalizedValue());
+            $this->assertEquals('mailto:alice@example.org', $alarmsByUid['alice-personal-reminder@example.org']->ATTENDEE->getNormalizedValue());
         });
     }
 
@@ -653,7 +653,7 @@ SUMMARY:Original meeting
 ORGANIZER:mailto:bob@example.org
 ATTENDEE:mailto:alice@example.org
 BEGIN:VALARM
-UID:organizer-reminder@example.org
+UID:alarm-organizer-11111111-1111-4111-8111-111111111111
 ACTION:EMAIL
 ATTENDEE:mailto:alice@example.org
 TRIGGER:-PT5M
@@ -700,6 +700,13 @@ TRIGGER:-PT5M
 DESCRIPTION:Missing UID reminder
 END:VALARM
 BEGIN:VALARM
+ACTION:EMAIL
+ATTENDEE:mailto:alice@example.org
+TRIGGER:-PT7M
+DESCRIPTION:Missing organizer UID reminder
+SUMMARY:Alarm notification
+END:VALARM
+BEGIN:VALARM
 UID:client-reminder
 ACTION:EMAIL
 ATTENDEE:mailto:alice@example.org
@@ -712,12 +719,89 @@ END:VCALENDAR
 ICS
         );
 
-        $modified = $this->invokeEnsureValarmUids($calendar);
+        $modified = $this->invokeEnsureValarmUids($calendar, false);
 
         $alarms = $calendar->VEVENT->select('VALARM');
         $this->assertTrue($modified);
         $this->assertMatchesRegularExpression('/^alarm-[0-9a-fA-F-]{36}$/', $alarms[0]->UID->getValue());
-        $this->assertEquals('client-reminder', $alarms[1]->UID->getValue());
+        $this->assertMatchesRegularExpression('/^alarm-organizer-[0-9a-fA-F-]{36}$/', $alarms[1]->UID->getValue());
+        $this->assertEquals('client-reminder', $alarms[2]->UID->getValue());
+    }
+
+    function testShouldGeneratePersonalUIDAndPreserveProvidedUIDsOnAttendeeWrite() {
+        $organizerUid = 'alarm-organizer-11111111-1111-4111-8111-111111111111';
+        $forgedOrganizerUid = 'alarm-organizer-22222222-2222-4222-8222-222222222222';
+        $calendar = Reader::read(str_replace(
+            ['{organizerUid}', '{forgedOrganizerUid}'],
+            [$organizerUid, $forgedOrganizerUid],
+            <<<'ICS'
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:event-attendee-valarm-uids
+DTSTART:20351005T090000Z
+DTEND:20351005T100000Z
+ORGANIZER:mailto:bob@example.org
+ATTENDEE:mailto:alice@example.org
+BEGIN:VALARM
+UID:{organizerUid}
+ACTION:EMAIL
+ATTENDEE:mailto:alice@example.org
+TRIGGER:-PT5M
+END:VALARM
+BEGIN:VALARM
+ACTION:EMAIL
+ATTENDEE:mailto:alice@example.org
+TRIGGER:-PT10M
+END:VALARM
+BEGIN:VALARM
+UID:{forgedOrganizerUid}
+ACTION:EMAIL
+ATTENDEE:mailto:alice@example.org
+TRIGGER:-PT15M
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+ICS
+        ));
+
+        $modified = $this->invokeEnsureValarmUids($calendar, true);
+
+        $alarms = $calendar->VEVENT->select('VALARM');
+        $this->assertTrue($modified);
+        $this->assertEquals($organizerUid, $alarms[0]->UID->getValue());
+        $this->assertMatchesRegularExpression('/^alarm-personal-[0-9a-fA-F-]{36}$/', $alarms[1]->UID->getValue());
+        $this->assertEquals($forgedOrganizerUid, $alarms[2]->UID->getValue());
+    }
+
+    function testShouldPreserveProvidedPersonalUIDOnOrganizerWrite() {
+        $calendar = Reader::read(<<<'ICS'
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+UID:event-organizer-valarm-uids
+DTSTART:20351005T090000Z
+DTEND:20351005T100000Z
+ORGANIZER:mailto:bob@example.org
+ATTENDEE:mailto:alice@example.org
+BEGIN:VALARM
+UID:alarm-personal-33333333-3333-4333-8333-333333333333
+ACTION:EMAIL
+ATTENDEE:mailto:alice@example.org
+TRIGGER:-PT5M
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+ICS
+        );
+
+        $modified = $this->invokeEnsureValarmUids($calendar, false);
+
+        $this->assertFalse($modified);
+        $this->assertEquals(
+            'alarm-personal-33333333-3333-4333-8333-333333333333',
+            $calendar->VEVENT->VALARM->UID->getValue()
+        );
     }
 
     function testShouldRejectForbiddenAttendeeSchedulingObjectChanges() {
@@ -1211,11 +1295,11 @@ ICS
         $method->invoke($this->plugin, $message, $sourceCalendar);
     }
 
-    private function invokeEnsureValarmUids($calendarObject): bool {
+    private function invokeEnsureValarmUids($calendarObject, bool $isAttendeeCalendarWrite): bool {
         $method = new \ReflectionMethod(Plugin::class, 'ensureValarmUids');
         $method->setAccessible(true);
 
-        return $method->invoke($this->plugin, $calendarObject);
+        return $method->invoke($this->plugin, $calendarObject, $isAttendeeCalendarWrite);
     }
 
     private function invokeShouldEnableEmailValarmRecipientScheduling(): bool {

--- a/tests/CalDAV/Schedule/SchedulePluginTest.php
+++ b/tests/CalDAV/Schedule/SchedulePluginTest.php
@@ -774,6 +774,13 @@ ICS
         $this->assertEquals($forgedOrganizerUid, $alarms[2]->UID->getValue());
     }
 
+    function testShouldTreatTeamCalendarWriteAsOrganizerManaged() {
+        $calendar = Reader::read($this->newCalendarObject('event-team', 'bob@example.org'));
+
+        $this->assertTrue($this->invokeIsAttendeeCalendarWrite($calendar, false, ['mailto:alice@example.org']));
+        $this->assertFalse($this->invokeIsAttendeeCalendarWrite($calendar, true, ['mailto:alice@example.org']));
+    }
+
     function testShouldPreserveProvidedPersonalUIDOnOrganizerWrite() {
         $calendar = Reader::read(<<<'ICS'
 BEGIN:VCALENDAR
@@ -1300,6 +1307,13 @@ ICS
         $method->setAccessible(true);
 
         return $method->invoke($this->plugin, $calendarObject, $isAttendeeCalendarWrite);
+    }
+
+    private function invokeIsAttendeeCalendarWrite($calendarObject, bool $isTeamCalendar, array $actorAddresses): bool {
+        $method = new \ReflectionMethod(Plugin::class, 'isAttendeeCalendarWrite');
+        $method->setAccessible(true);
+
+        return $method->invoke($this->plugin, $calendarObject, $isTeamCalendar, $actorAddresses);
     }
 
     private function invokeShouldEnableEmailValarmRecipientScheduling(): bool {


### PR DESCRIPTION
resolve https://github.com/linagora/esn-sabre/issues/409

## Context
- VALARM UID is used as the stable identifier during scheduling merges.
- UID alone does not indicate alarm ownership.
- Requiring clients to generate ownership-aware UIDs adds unnecessary frontend complexity.

## How
- When UID is missing, `esn-sabre` now generates:
  - `alarm-organizer-{uuid}` for organizer/source writes and iTIP `REQUEST`;
  - `alarm-personal-{uuid}` for attendee-copy HTTP writes.

- Clients only need to preserve the server-generated UID received through subsequent calendar reads and reuse it in later full-resource writes.

Then: Attendee personal alarms are preserved